### PR TITLE
Integrate HelloAsso (API v5) with Feign clients, service, controller and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 Correction U11F enregistrement impossible
+
+## Intégration HelloAsso (backend)
+
+Le backend utilise maintenant des clients **Feign** pour appeler HelloAsso:
+- `HelloAssoAuthClient` (OAuth2 token)
+- `HelloAssoCheckoutClient` (checkout intents)
+
+Variables d'environnement :
+- `HELLOASSO_ORGANIZATION_SLUG`
+- `HELLOASSO_CLIENT_ID`
+- `HELLOASSO_CLIENT_SECRET`
+
+Endpoints API:
+- `POST /helloasso/checkout-intents`
+- `GET /helloasso/checkout-intents/{checkoutIntentId}`

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -44,6 +44,10 @@
 
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.2</version>
@@ -130,6 +134,27 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
             <version>2.8.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mockserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-client-java</artifactId>
+            <version>5.15.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/app/src/main/java/com/wild/corp/AdhesionWebApp.java
+++ b/app/src/main/java/com/wild/corp/AdhesionWebApp.java
@@ -13,9 +13,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 
 @SpringBootApplication
+@EnableFeignClients
 public class AdhesionWebApp {
 
 	@Autowired

--- a/app/src/main/java/com/wild/corp/adhesion/config/HelloAssoProperties.java
+++ b/app/src/main/java/com/wild/corp/adhesion/config/HelloAssoProperties.java
@@ -1,0 +1,19 @@
+package com.wild.corp.adhesion.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "helloasso")
+public class HelloAssoProperties {
+
+    private String baseUrl = "https://api.helloasso.com/v5";
+    private String oauthUrl = "https://api.helloasso.com/oauth2/token";
+    private String organizationSlug;
+    private String clientId;
+    private String clientSecret;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/HelloAssoController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/HelloAssoController.java
@@ -1,0 +1,37 @@
+package com.wild.corp.adhesion.controllers;
+
+import com.wild.corp.adhesion.models.helloasso.HelloAssoCheckoutRequest;
+import com.wild.corp.adhesion.services.HelloAssoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/helloasso")
+@RequiredArgsConstructor
+@Slf4j
+@CrossOrigin(origins = "*", maxAge = 3600)
+public class HelloAssoController {
+
+    private final HelloAssoService helloAssoService;
+
+    @PostMapping("/checkout-intents")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> createCheckoutIntent(Authentication principal, @Valid @RequestBody HelloAssoCheckoutRequest request) {
+        log.info("createCheckoutIntent by {} for adhesionId={}", principal.getName(), request.getAdhesionId());
+        return ResponseEntity.ok(helloAssoService.createCheckoutIntent(request));
+    }
+
+    @GetMapping("/checkout-intents/{checkoutIntentId}")
+    @PreAuthorize("hasRole('USER') or hasRole('SECRETAIRE') or hasRole('ADMIN')")
+    public ResponseEntity<Map<String, Object>> getCheckoutIntent(Authentication principal, @PathVariable Integer checkoutIntentId) {
+        log.info("getCheckoutIntent by {} for checkoutIntentId={}", principal.getName(), checkoutIntentId);
+        return ResponseEntity.ok(helloAssoService.getCheckoutIntent(checkoutIntentId));
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoCheckoutRequest.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoCheckoutRequest.java
@@ -1,0 +1,21 @@
+package com.wild.corp.adhesion.models.helloasso;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class HelloAssoCheckoutRequest {
+
+    @NotNull
+    private Long adhesionId;
+
+    @NotBlank
+    private String returnUrl;
+
+    @NotBlank
+    private String errorUrl;
+
+    @NotBlank
+    private String backUrl;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoCheckoutResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoCheckoutResponse.java
@@ -1,0 +1,11 @@
+package com.wild.corp.adhesion.models.helloasso;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HelloAssoCheckoutResponse {
+    private Integer checkoutIntentId;
+    private String redirectUrl;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoTokenResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/helloasso/HelloAssoTokenResponse.java
@@ -1,0 +1,17 @@
+package com.wild.corp.adhesion.models.helloasso;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class HelloAssoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/HelloAssoService.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/HelloAssoService.java
@@ -1,0 +1,113 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.config.HelloAssoProperties;
+import com.wild.corp.adhesion.models.Adhesion;
+import com.wild.corp.adhesion.models.helloasso.HelloAssoCheckoutRequest;
+import com.wild.corp.adhesion.models.helloasso.HelloAssoCheckoutResponse;
+import com.wild.corp.adhesion.models.helloasso.HelloAssoTokenResponse;
+import com.wild.corp.adhesion.repository.AdhesionRepository;
+import com.wild.corp.adhesion.services.helloasso.HelloAssoAuthClient;
+import com.wild.corp.adhesion.services.helloasso.HelloAssoCheckoutClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HelloAssoService {
+
+    private final HelloAssoProperties properties;
+    private final AdhesionRepository adhesionRepository;
+    private final HelloAssoAuthClient helloAssoAuthClient;
+    private final HelloAssoCheckoutClient helloAssoCheckoutClient;
+
+    private String accessToken;
+    private Instant tokenExpiresAt;
+
+    public HelloAssoCheckoutResponse createCheckoutIntent(HelloAssoCheckoutRequest request) {
+        Adhesion adhesion = adhesionRepository.findById(request.getAdhesionId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Adhesion not found: " + request.getAdhesionId()));
+
+        Map<String, Object> body = new HashMap<>();
+        int amountInCents = adhesion.getTarif() * 100;
+        body.put("totalAmount", amountInCents);
+        body.put("initialAmount", amountInCents);
+        body.put("itemName", "Adhesion " + adhesion.getActivite().getNom() + " #" + adhesion.getId());
+        body.put("backUrl", request.getBackUrl());
+        body.put("errorUrl", request.getErrorUrl());
+        body.put("returnUrl", request.getReturnUrl());
+        body.put("containsDonation", false);
+        body.put("metadata", Map.of("adhesionId", adhesion.getId()));
+
+        Map<String, Object> payload = helloAssoCheckoutClient.createCheckoutIntent(
+                bearerToken(),
+                properties.getOrganizationSlug(),
+                body
+        );
+
+        Number id = (Number) payload.get("id");
+        String redirectUrl = (String) payload.get("redirectUrl");
+
+        return HelloAssoCheckoutResponse.builder()
+                .checkoutIntentId(id == null ? null : id.intValue())
+                .redirectUrl(redirectUrl)
+                .build();
+    }
+
+    public Map<String, Object> getCheckoutIntent(Integer checkoutIntentId) {
+        return helloAssoCheckoutClient.getCheckoutIntent(
+                bearerToken(),
+                properties.getOrganizationSlug(),
+                checkoutIntentId
+        );
+    }
+
+    private String bearerToken() {
+        return "Bearer " + getAccessToken();
+    }
+
+    private synchronized String getAccessToken() {
+        validateConfiguration();
+        if (accessToken != null && tokenExpiresAt != null && Instant.now().isBefore(tokenExpiresAt)) {
+            return accessToken;
+        }
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "client_credentials");
+        form.add("client_id", properties.getClientId());
+        form.add("client_secret", properties.getClientSecret());
+
+        HelloAssoTokenResponse tokenResponse = helloAssoAuthClient.getAccessToken(form);
+        if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+            throw new IllegalStateException("Unable to retrieve HelloAsso access token");
+        }
+
+        accessToken = tokenResponse.getAccessToken();
+        int expiresIn = tokenResponse.getExpiresIn() == null ? 3600 : tokenResponse.getExpiresIn();
+        tokenExpiresAt = Instant.now().plusSeconds(Math.max(60, expiresIn - 30L));
+
+        log.info("HelloAsso access token refreshed, expires in {} seconds", expiresIn);
+        return accessToken;
+    }
+
+    private void validateConfiguration() {
+        if (properties.getOrganizationSlug() == null || properties.getOrganizationSlug().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "HELLOASSO_ORGANIZATION_SLUG is missing");
+        }
+        if (properties.getClientId() == null || properties.getClientId().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "HELLOASSO_CLIENT_ID is missing");
+        }
+        if (properties.getClientSecret() == null || properties.getClientSecret().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "HELLOASSO_CLIENT_SECRET is missing");
+        }
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/helloasso/HelloAssoAuthClient.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/helloasso/HelloAssoAuthClient.java
@@ -1,0 +1,15 @@
+package com.wild.corp.adhesion.services.helloasso;
+
+import com.wild.corp.adhesion.models.helloasso.HelloAssoTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "helloAssoAuthClient", url = "${helloasso.oauth-url}")
+public interface HelloAssoAuthClient {
+
+    @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    HelloAssoTokenResponse getAccessToken(@RequestBody MultiValueMap<String, String> form);
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/helloasso/HelloAssoCheckoutClient.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/helloasso/HelloAssoCheckoutClient.java
@@ -1,0 +1,24 @@
+package com.wild.corp.adhesion.services.helloasso;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.Map;
+
+@FeignClient(name = "helloAssoCheckoutClient", url = "${helloasso.base-url}")
+public interface HelloAssoCheckoutClient {
+
+    @PostMapping("/organizations/{organizationSlug}/checkout-intents")
+    Map<String, Object> createCheckoutIntent(@RequestHeader("Authorization") String authorization,
+                                             @PathVariable String organizationSlug,
+                                             @RequestBody Map<String, Object> body);
+
+    @GetMapping("/organizations/{organizationSlug}/checkout-intents/{checkoutIntentId}")
+    Map<String, Object> getCheckoutIntent(@RequestHeader("Authorization") String authorization,
+                                          @PathVariable String organizationSlug,
+                                          @PathVariable Integer checkoutIntentId);
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -29,3 +29,9 @@ server:
     jwtExpirationMs: 86400000
 
 image-storage-dir: C:\Users\PC\Documents\ProjetsDev\Adhesion
+helloasso:
+  base-url: ${HELLOASSO_BASE_URL:https://api.helloasso.com/v5}
+  oauth-url: ${HELLOASSO_OAUTH_URL:https://api.helloasso.com/oauth2/token}
+  organization-slug: ${HELLOASSO_ORGANIZATION_SLUG:}
+  client-id: ${HELLOASSO_CLIENT_ID:}
+  client-secret: ${HELLOASSO_CLIENT_SECRET:}

--- a/app/src/test/java/com/wild/corp/adhesion/services/HelloAssoServiceContainerTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/HelloAssoServiceContainerTest.java
@@ -1,0 +1,136 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.config.HelloAssoProperties;
+import com.wild.corp.adhesion.models.Activite;
+import com.wild.corp.adhesion.models.Adhesion;
+import com.wild.corp.adhesion.models.helloasso.HelloAssoCheckoutRequest;
+import com.wild.corp.adhesion.models.helloasso.HelloAssoCheckoutResponse;
+import com.wild.corp.adhesion.repository.AdhesionRepository;
+import com.wild.corp.adhesion.services.helloasso.HelloAssoAuthClient;
+import com.wild.corp.adhesion.services.helloasso.HelloAssoCheckoutClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = HelloAssoServiceContainerTest.TestConfig.class)
+@Testcontainers
+class HelloAssoServiceContainerTest {
+
+    @Container
+    static MockServerContainer mockServerContainer = new MockServerContainer(DockerImageName.parse("mockserver/mockserver:5.15.0"));
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        String endpoint = "http://" + mockServerContainer.getHost() + ":" + mockServerContainer.getServerPort();
+        registry.add("helloasso.base-url", () -> endpoint);
+        registry.add("helloasso.oauth-url", () -> endpoint + "/oauth2/token");
+        registry.add("helloasso.organization-slug", () -> "asso-test");
+        registry.add("helloasso.client-id", () -> "client-id-test");
+        registry.add("helloasso.client-secret", () -> "client-secret-test");
+    }
+
+    @Autowired
+    private HelloAssoService helloAssoService;
+
+    @MockBean
+    private AdhesionRepository adhesionRepository;
+
+    private MockServerClient mockServerClient;
+
+    @BeforeEach
+    void setUp() {
+        mockServerClient = new MockServerClient(mockServerContainer.getHost(), mockServerContainer.getServerPort());
+        mockServerClient.reset();
+    }
+
+    @Test
+    void shouldCreateCheckoutIntent() {
+        Adhesion adhesion = new Adhesion();
+        adhesion.setId(42L);
+        adhesion.setTarif(180);
+        Activite activite = new Activite();
+        activite.setNom("Basket U13");
+        adhesion.setActivite(activite);
+
+        when(adhesionRepository.findById(42L)).thenReturn(Optional.of(adhesion));
+
+        mockServerClient
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/oauth2/token"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"access_token\":\"token-123\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"));
+
+        mockServerClient
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/organizations/asso-test/checkout-intents"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"id\":12345,\"redirectUrl\":\"https://helloasso.test/checkout/12345\"}"));
+
+        HelloAssoCheckoutRequest request = new HelloAssoCheckoutRequest();
+        request.setAdhesionId(42L);
+        request.setBackUrl("https://front.test/back");
+        request.setErrorUrl("https://front.test/error");
+        request.setReturnUrl("https://front.test/return");
+
+        HelloAssoCheckoutResponse response = helloAssoService.createCheckoutIntent(request);
+
+        assertThat(response.getCheckoutIntentId()).isEqualTo(12345);
+        assertThat(response.getRedirectUrl()).isEqualTo("https://helloasso.test/checkout/12345");
+
+        mockServerClient.verify(request().withMethod("POST").withPath("/oauth2/token"));
+        mockServerClient.verify(request().withMethod("POST").withPath("/organizations/asso-test/checkout-intents"));
+    }
+
+    @SpringBootConfiguration
+    @EnableConfigurationProperties(HelloAssoProperties.class)
+    @EnableFeignClients(clients = {HelloAssoAuthClient.class, HelloAssoCheckoutClient.class})
+    @EnableAutoConfiguration(exclude = {
+            DataSourceAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            JpaRepositoriesAutoConfiguration.class
+    })
+    static class TestConfig {
+        @Bean
+        HelloAssoService helloAssoService(HelloAssoProperties properties,
+                                          AdhesionRepository adhesionRepository,
+                                          HelloAssoAuthClient helloAssoAuthClient,
+                                          HelloAssoCheckoutClient helloAssoCheckoutClient) {
+            return new HelloAssoService(properties, adhesionRepository, helloAssoAuthClient, helloAssoCheckoutClient);
+        }
+    }
+
+}

--- a/docs/integration-helloasso.md
+++ b/docs/integration-helloasso.md
@@ -1,0 +1,123 @@
+# Proposition d’intégration HelloAsso (API v5) dans Adhesion
+
+## Objectifs
+- Permettre un paiement en ligne HelloAsso depuis le parcours d’adhésion.
+- Réconcilier automatiquement les paiements HelloAsso avec les `Adhesion` et `Paiement` existants.
+- Conserver un fallback manuel pour le secrétariat (virements/chèques déjà gérés).
+
+## Constat sur le projet actuel
+- Le backend dispose déjà d’un modèle `Paiement` rattaché à `Adhesion` (`List<Paiement>`), ce qui donne un bon point d’entrée pour enregistrer les règlements en provenance d’HelloAsso.
+- L’API interne expose déjà des endpoints de création/suppression de paiements (`/adhesion/savePaiement`, `/adhesion/deletePaiement`) et de validation du paiement côté secrétariat (`/adhesion/updatePaiementSecretariat`).
+- Une spécification OpenAPI HelloAsso est déjà présente dans le repo (`app/src/main/resources/helloasso.json`), donc le besoin est surtout l’intégration métier/sécurité.
+
+## Architecture cible (simple et robuste)
+
+### 1) Backend Spring : module d’intégration dédié
+Créer une couche dédiée, par exemple :
+- `services/helloasso/HelloAssoAuthService` : récupère et met en cache le token OAuth2 client_credentials.
+- `services/helloasso/HelloAssoCheckoutService` : crée un checkout intent (`POST /v5/organizations/{slug}/checkout-intents`).
+- `services/helloasso/HelloAssoWebhookService` : traite les événements de paiement asynchrones.
+- `controllers/HelloAssoController` : endpoints internes exposés au front.
+
+### 2) Flux “paiement en ligne”
+1. Le front demande au backend de créer une session de paiement pour une `adhesionId`.
+2. Le backend appelle HelloAsso pour créer le checkout intent et retourne `redirectUrl` au front.
+3. Le front redirige l’utilisateur vers HelloAsso.
+4. À la fin du paiement, HelloAsso notifie votre webhook backend.
+5. Le backend mappe l’événement sur `Adhesion`, crée un `Paiement`, et positionne `validPaiementSecretariat=true` si vous souhaitez une validation automatique des paiements CB.
+
+### 3) Corrélation des données
+Le point critique est de lier de façon fiable un paiement HelloAsso à une adhésion interne.
+
+Recommandation :
+- Générer une référence interne unique (ex: `ADH-{adhesionId}-{timestamp}`) lors de la création du checkout.
+- La transmettre dans les métadonnées/description du checkout intent.
+- À réception webhook, rechercher l’adhésion via cette référence.
+
+## Endpoints backend proposés
+
+### `POST /helloasso/checkout`
+Entrée:
+```json
+{
+  "adhesionId": 123,
+  "returnUrl": "https://votre-front/paiement/success",
+  "cancelUrl": "https://votre-front/paiement/cancel"
+}
+```
+
+Sortie:
+```json
+{
+  "checkoutIntentId": 456789,
+  "redirectUrl": "https://www.helloasso.com/associations/...",
+  "reference": "ADH-123-1710000000"
+}
+```
+
+### `POST /helloasso/webhook`
+- Endpoint appelé par HelloAsso.
+- Vérifie l’authenticité (signature/token webhook si configuré dans HelloAsso).
+- Idempotence obligatoire (ne pas créer 2 paiements pour le même `orderId`).
+
+### `GET /helloasso/checkout/{checkoutIntentId}`
+- Endpoint de support pour vérifier l’état d’un checkout intent côté BO (optionnel mais utile au secrétariat).
+
+## Mapping métier recommandé
+Lors d’un paiement confirmé :
+- Créer un `Paiement` avec:
+  - `dateReglement = date du paiement`
+  - `typeReglement = "HELLOASSO"`
+  - `montant = montant payé (centimes -> euros selon convention interne)`
+- Ajouter ce `Paiement` à l’`Adhesion` correspondante.
+- Mettre à jour `validPaiementSecretariat` selon votre règle métier.
+
+## Sécurité & conformité
+- Secrets en variables d’environnement (jamais en dur) :
+  - `HELLOASSO_CLIENT_ID`
+  - `HELLOASSO_CLIENT_SECRET`
+  - `HELLOASSO_ORGANIZATION_SLUG`
+  - `HELLOASSO_WEBHOOK_SECRET` (si utilisé)
+- Journaliser les échanges sans exposer tokens/PII.
+- Mettre en place des timeouts/retries et circuit breaker léger pour l’API externe.
+
+## Modifications techniques minimales à prévoir
+
+### `application.yml`
+Ajouter une section typée :
+```yaml
+helloasso:
+  base-url: https://api.helloasso.com/v5
+  organization-slug: ${HELLOASSO_ORGANIZATION_SLUG}
+  client-id: ${HELLOASSO_CLIENT_ID}
+  client-secret: ${HELLOASSO_CLIENT_SECRET}
+  webhook-secret: ${HELLOASSO_WEBHOOK_SECRET:}
+```
+
+### Backend
+- Ajouter des DTOs d’échange (`CheckoutRequest`, `CheckoutResponse`, `WebhookEvent`).
+- Ajouter un client HTTP (WebClient ou RestTemplate) pour HelloAsso.
+- Ajouter une table d’idempotence webhook (ex: `helloasso_events`) ou une contrainte unique sur identifiant d’ordre.
+
+### Frontend Angular
+- Ajouter un bouton “Payer en ligne (HelloAsso)” sur l’écran d’adhésion.
+- Appeler `POST /helloasso/checkout` puis redirection navigateur vers `redirectUrl`.
+- Ajouter une page de retour (`/paiement/success` / `/paiement/cancel`) qui relit l’état adhésion.
+
+## Stratégie de mise en œuvre en 3 lots
+1. **Lot 1 (MVP)**: création checkout + redirection + webhook + création `Paiement`.
+2. **Lot 2**: robustesse (idempotence stricte, monitoring, retries, logs structurés).
+3. **Lot 3**: UX BO (écran de suivi des transactions HelloAsso, rapprochement manuel assisté).
+
+## Risques principaux à anticiper
+- Paiement validé chez HelloAsso mais webhook non reçu (prévoir job de réconciliation périodique via API HelloAsso).
+- Doublons webhook (idempotence obligatoire).
+- Différences de format montant/taxes/commission selon le type de formulaire HelloAsso.
+
+## Proposition concrète pour ton repo
+Je te recommande de démarrer par une intégration backend-only très cadrée :
+- Nouveau package `com.wild.corp.adhesion.integration.helloasso`.
+- 1 controller (`HelloAssoController`) + 2 services (`Auth`, `Checkout`) + 1 service webhook.
+- Réutilisation directe de ton modèle `Paiement` existant (pas de refonte DB initiale, uniquement une table d’idempotence).
+
+Ensuite, côté front, un simple CTA “Payer en ligne” dans la vue adhésion suffit pour déclencher le flux.


### PR DESCRIPTION
### Motivation

- Add backend support to create and retrieve HelloAsso checkout intents and manage OAuth2 client_credentials tokens for online payments. 
- Provide configurable properties and safe token caching so the backend can call HelloAsso on behalf of users and expose simple endpoints for the frontend and BO.

### Description

- Add `HelloAssoProperties` and `application.yml` keys for `helloasso.base-url`, `helloasso.oauth-url`, `helloasso.organization-slug`, `helloasso.client-id` and `helloasso.client-secret` to drive configuration from environment variables. 
- Introduce two Feign clients `HelloAssoAuthClient` and `HelloAssoCheckoutClient` and enable Feign with `@EnableFeignClients` in `AdhesionWebApp`, plus add `spring-cloud-starter-openfeign` dependency. 
- Implement `HelloAssoService` that manages OAuth token retrieval/caching and exposes `createCheckoutIntent` and `getCheckoutIntent`, plus add `HelloAssoController` and DTOs `HelloAssoCheckoutRequest`, `HelloAssoCheckoutResponse`, `HelloAssoTokenResponse`. 
- Add integration documentation `docs/integration-helloasso.md`, update `README.md`, and add test dependencies (`spring-boot-starter-test`, Testcontainers and MockServer client) and a container-based test `HelloAssoServiceContainerTest` that verifies checkout creation via a MockServer instance.

### Testing

- Added `HelloAssoServiceContainerTest` which runs with Testcontainers MockServer and mocks the OAuth token and checkout-intent API calls; the test verifies the returned `checkoutIntentId` and `redirectUrl` and the expected external requests were invoked, and it passed. 
- No other automated tests were modified and existing test suites remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ef6214008321a7e95716cc2f0f5d)