### PR TITLE
Mettre à jour dépendances Maven, migrer JWT à JJWT 0.13, fiabiliser la compression et ajouter des tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -17,13 +17,19 @@
     <properties>
         <java.version>21</java.version>
         <maven.compiler.proc>full</maven.compiler.proc>
+        <brevo.version>1.1.9</brevo.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <jackson-databind-nullable.version>0.2.11</jackson-databind-nullable.version>
+        <jjwt.version>0.13.0</jjwt.version>
+        <openapi-generator.version>7.24.0</openapi-generator.version>
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.brevo</groupId>
             <artifactId>brevo</artifactId>
-            <version>1.1.0</version>
+            <version>${brevo.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,42 +57,30 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>${postgresql.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.mailersend</groupId>
-            <artifactId>java-sdk</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.mailjet/mailjet-client -->
-        <dependency>
-            <groupId>com.mailjet</groupId>
-            <artifactId>mailjet-client</artifactId>
-            <version>5.2.5</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -129,7 +123,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.1</version>
+            <version>${jackson-databind-nullable.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -158,7 +152,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.12.0</version>
+                <version>${openapi-generator.version}</version>
                 <executions>
                     <execution>
                         <id>ApiHelloasso</id>

--- a/app/src/main/java/com/wild/corp/adhesion/security/jwt/JwtUtils.java
+++ b/app/src/main/java/com/wild/corp/adhesion/security/jwt/JwtUtils.java
@@ -2,40 +2,55 @@ package com.wild.corp.adhesion.security.jwt;
 
 import com.wild.corp.adhesion.models.UserDetails;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Date;
 
 @Component
 public class JwtUtils {
   private static final Logger logger = LoggerFactory.getLogger(JwtUtils.class);
 
-  @Value("${server.app.jwtSecret}")
-  private String jwtSecret;
+  private final SecretKey signingKey;
+  private final long jwtExpirationMs;
+  private final Clock clock;
 
-  @Value("${server.app.jwtExpirationMs}")
-  private int jwtExpirationMs;
+  public JwtUtils(@Value("${server.app.jwtSecret}") String jwtSecret,
+                  @Value("${server.app.jwtExpirationMs}") long jwtExpirationMs) {
+    this(jwtSecret, jwtExpirationMs, Clock.systemUTC());
+  }
+
+  JwtUtils(String jwtSecret, long jwtExpirationMs, Clock clock) {
+    this.signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    this.jwtExpirationMs = jwtExpirationMs;
+    this.clock = clock;
+  }
 
   public String generateJwtToken(Authentication authentication) {
 
     UserDetails userPrincipal = (UserDetails) authentication.getPrincipal();
 
-    return Jwts.builder().setSubject((userPrincipal.getUsername())).setIssuedAt(new Date())
-        .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs)).signWith(SignatureAlgorithm.HS512, jwtSecret)
+    Date issuedAt = Date.from(clock.instant());
+    return Jwts.builder().subject(userPrincipal.getUsername()).issuedAt(issuedAt)
+        .expiration(new Date(issuedAt.getTime() + jwtExpirationMs)).signWith(signingKey)
         .compact();
   }
 
   public String getUserNameFromJwtToken(String token) {
-    return Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody().getSubject();
+    return parser().parseSignedClaims(token).getPayload().getSubject();
   }
 
   public boolean validateJwtToken(String authToken) {
     try {
-      Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(authToken);
+      parser().parseSignedClaims(authToken);
       return true;
     } catch (SignatureException e) {
       logger.error("Invalid JWT signature: {}", e.getMessage());
@@ -50,5 +65,9 @@ public class JwtUtils {
     }
 
     return false;
+  }
+
+  private JwtParser parser() {
+    return Jwts.parser().verifyWith(signingKey).clock(() -> Date.from(clock.instant())).build();
   }
 }

--- a/app/src/main/java/com/wild/corp/adhesion/services/ImageUtils.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/ImageUtils.java
@@ -1,44 +1,55 @@
 package com.wild.corp.adhesion.services;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Objects;
+import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
 public class ImageUtils {
 
+    private ImageUtils() {
+    }
+
     public static byte[] compressImage(byte[] data) {
-
+        Objects.requireNonNull(data, "Les données à compresser sont obligatoires");
         Deflater deflater = new Deflater();
-        deflater.setLevel(Deflater.BEST_COMPRESSION);
-        deflater.setInput(data);
-        deflater.finish();
-
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-        byte[] tmp = new byte[4*1024];
-        while (!deflater.finished()) {
-            int size = deflater.deflate(tmp);
-            outputStream.write(tmp, 0, size);
-        }
         try {
-            outputStream.close();
-        } catch (Exception e) {
+            deflater.setLevel(Deflater.BEST_COMPRESSION);
+            deflater.setInput(data);
+            deflater.finish();
+
+            byte[] buffer = new byte[4 * 1024];
+            while (!deflater.finished()) {
+                int size = deflater.deflate(buffer);
+                outputStream.write(buffer, 0, size);
+            }
+            return outputStream.toByteArray();
+        } finally {
+            deflater.end();
         }
-        return outputStream.toByteArray();
     }
 
     public static byte[] decompressImage(byte[] data) {
+        Objects.requireNonNull(data, "Les données à décompresser sont obligatoires");
         Inflater inflater = new Inflater();
-        inflater.setInput(data);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-        byte[] tmp = new byte[4*1024];
         try {
+            inflater.setInput(data);
+            byte[] buffer = new byte[4 * 1024];
             while (!inflater.finished()) {
-                int count = inflater.inflate(tmp);
-                outputStream.write(tmp, 0, count);
+                int count = inflater.inflate(buffer);
+                if (count == 0 && (inflater.needsInput() || inflater.needsDictionary())) {
+                    throw new IllegalArgumentException("Les données compressées sont incomplètes ou invalides");
+                }
+                outputStream.write(buffer, 0, count);
             }
-            outputStream.close();
-        } catch (Exception exception) {
+            return outputStream.toByteArray();
+        } catch (DataFormatException exception) {
+            throw new IllegalArgumentException("Les données compressées sont invalides", exception);
+        } finally {
+            inflater.end();
         }
-        return outputStream.toByteArray();
     }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -25,6 +25,7 @@ logging.level.org.hibernate: ERROR
 server:
   name : ${DNS_NAME}
   app:
+    # Une clé d'au moins 64 octets est requise pour signer les jetons en HS512.
     jwtSecret: ${JWT_SECRET}
     jwtExpirationMs: 86400000
 

--- a/app/src/test/java/com/wild/corp/adhesion/security/jwt/JwtUtilsTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/security/jwt/JwtUtilsTest.java
@@ -1,0 +1,52 @@
+package com.wild.corp.adhesion.security.jwt;
+
+import com.wild.corp.adhesion.models.UserDetails;
+import io.jsonwebtoken.security.WeakKeyException;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtUtilsTest {
+
+    private static final String SECRET = "a-secure-signing-secret-with-at-least-64-bytes-for-the-HS512-algorithm";
+    private static final Instant NOW = Instant.parse("2026-08-03T12:00:00Z");
+
+    @Test
+    void generatesAndReadsAValidToken() {
+        JwtUtils jwtUtils = jwtUtils(60_000);
+        UserDetails principal = new UserDetails(42L, "member@example.org", "secret", List.of());
+
+        String token = jwtUtils.generateJwtToken(
+                new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities()));
+
+        assertThat(jwtUtils.validateJwtToken(token)).isTrue();
+        assertThat(jwtUtils.getUserNameFromJwtToken(token)).isEqualTo("member@example.org");
+    }
+
+    @Test
+    void rejectsExpiredAndTamperedTokens() {
+        JwtUtils jwtUtils = jwtUtils(-1);
+        UserDetails principal = new UserDetails(42L, "member@example.org", "secret", List.of());
+        String token = jwtUtils.generateJwtToken(new UsernamePasswordAuthenticationToken(principal, "secret"));
+
+        assertThat(jwtUtils.validateJwtToken(token)).isFalse();
+        assertThat(jwtUtils(60_000).validateJwtToken(token + "invalid")).isFalse();
+    }
+
+    @Test
+    void refusesAWeakSigningSecret() {
+        assertThatThrownBy(() -> new JwtUtils("too-short", 60_000, Clock.systemUTC()))
+                .isInstanceOf(WeakKeyException.class);
+    }
+
+    private JwtUtils jwtUtils(long expirationMs) {
+        return new JwtUtils(SECRET, expirationMs, Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+}

--- a/app/src/test/java/com/wild/corp/adhesion/services/ImageUtilsTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/ImageUtilsTest.java
@@ -1,0 +1,28 @@
+package com.wild.corp.adhesion.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ImageUtilsTest {
+
+    @Test
+    void compressesAndDecompressesWithoutLosingData() {
+        byte[] original = "image-content".repeat(1_000).getBytes(StandardCharsets.UTF_8);
+
+        byte[] compressed = ImageUtils.compressImage(original);
+
+        assertThat(compressed).isNotEqualTo(original).hasSizeLessThan(original.length);
+        assertThat(ImageUtils.decompressImage(compressed)).isEqualTo(original);
+    }
+
+    @Test
+    void rejectsInvalidCompressedData() {
+        assertThatThrownBy(() -> ImageUtils.decompressImage(new byte[]{1, 2, 3}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalides");
+    }
+}


### PR DESCRIPTION
### Motivation

- Moderniser et centraliser les versions des dépendances Maven pour réduire la dette technique et faciliter les mises à jour ultérieures.  
- Renforcer la sécurité et la testabilité de la gestion des JWT en utilisant l’API JJWT moderne et une clé typée.  
- Fiabiliser la compression/décompression d’images et ajouter des tests pour prévenir les régressions critiques.  

### Description

- Mise à jour du `pom.xml` : centralisation des versions (`brevo.version`, `commons-lang3.version`, `jjwt.version`, `jackson-databind-nullable.version`, `openapi-generator.version`, `postgresql.version`), suppression de SDK inutilisés et mise en `runtime` du driver PostgreSQL.  
- Migration de la gestion JWT (`JwtUtils`) vers JJWT 0.13 : utilisation d’un `SecretKey` (`Keys.hmacShaKeyFor`), horloge injectable (`Clock`) pour des tests déterministes, `jwtExpirationMs` en `long`, nouvel utilitaire `parser()` et gestion d’erreurs adaptée.  
- Refactor de `ImageUtils` : validation d’entrée, libération explicite des ressources natives `Deflater`/`Inflater`, détection et propagation des données compressées invalides via `IllegalArgumentException`, et constructeur privé pour utilitaire statique.  
- Ajout de tests unitaires : `JwtUtilsTest` (génération/validation/expiration/altération/clé faible) et `ImageUtilsTest` (intégrité compression-décompression et rejet d’entrées invalides), et mise à jour de la propriété `openapi-generator` pour génération de sources lors du build.  

### Testing

- Exécution automatique : `mvn -B test` a été lancée et le build de l’application a réussi avec tous les tests unitaires (6 tests) verts.  
- La génération OpenAPI intégrée au build s’est exécutée sans bloquer la compilation et les sources client générées ont été écrites pendant le build.  
- Aucun test automatisé n’a échoué après les modifications (résultat du cycle de tests Maven : BUILD SUCCESS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70948540748321962c2fcd2fa4882b)