### PR TITLE
Ajout d'un endpoint pageable pour les adhésions et pagination côté client

### DIFF
--- a/app/src/main/java/com/wild/corp/adhesion/controllers/AdhesionController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/AdhesionController.java
@@ -118,9 +118,21 @@ AdhesionServices adhesionServices;
 	@GetMapping("/page")
 	@PreAuthorize("hasRole('SECRETAIRE') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")
 	public ResponseEntity<?> getPage(Authentication principal, @RequestParam(defaultValue = "Toutes") String sections,
+			@RequestParam(defaultValue = "") String search,
+			@RequestParam(defaultValue = "") String status,
+			@RequestParam(required = false) Boolean paymentValidated,
+			@RequestParam(required = false) Boolean documentsValidated,
+			@RequestParam(required = false) Boolean flagged,
 			@PageableDefault(size = 20, sort = {"adherent.nom", "adherent.prenom"}) Pageable pageable) {
 		log.info("getPage by " + principal.getName() + " for section " + sections);
-		return ResponseEntity.ok(adhesionServices.getAllLite(sections, pageable));
+		return ResponseEntity.ok(adhesionServices.getAllLite(sections, search, status, paymentValidated,
+				documentsValidated, flagged, pageable));
+	}
+
+	@GetMapping("/statuses")
+	@PreAuthorize("hasRole('SECRETAIRE') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")
+	public ResponseEntity<List<String>> getStatuses() {
+		return ResponseEntity.ok(adhesionServices.getStatuses());
 	}
 
 	@GetMapping("/liteBysection")

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/AdhesionController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/AdhesionController.java
@@ -8,6 +8,8 @@ import jakarta.websocket.server.PathParam;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -111,6 +113,14 @@ AdhesionServices adhesionServices;
 	public ResponseEntity<?> getAllLite(Authentication principal) {
 		log.info("getAllLite by " + principal.getName() );
 		return ResponseEntity.ok(adhesionServices.getAllLite());
+	}
+
+	@GetMapping("/page")
+	@PreAuthorize("hasRole('SECRETAIRE') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")
+	public ResponseEntity<?> getPage(Authentication principal, @RequestParam(defaultValue = "Toutes") String sections,
+			@PageableDefault(size = 20, sort = {"adherent.nom", "adherent.prenom"}) Pageable pageable) {
+		log.info("getPage by " + principal.getName() + " for section " + sections);
+		return ResponseEntity.ok(adhesionServices.getAllLite(sections, pageable));
 	}
 
 	@GetMapping("/liteBysection")

--- a/app/src/main/java/com/wild/corp/adhesion/repository/AdhesionRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/AdhesionRepository.java
@@ -2,6 +2,8 @@ package com.wild.corp.adhesion.repository;
 
 import com.wild.corp.adhesion.models.Activite;
 import com.wild.corp.adhesion.models.Adhesion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +15,8 @@ public interface AdhesionRepository extends JpaRepository<Adhesion, Long> {
 
     List<Adhesion> findByActiviteNom(String nom);
 
-}
+    Page<Adhesion> findByActiviteNom(String nom, Pageable pageable);
 
+    Page<Adhesion> findByActiviteId(Long id, Pageable pageable);
+
+}

--- a/app/src/main/java/com/wild/corp/adhesion/repository/AdhesionRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/AdhesionRepository.java
@@ -5,12 +5,14 @@ import com.wild.corp.adhesion.models.Adhesion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface AdhesionRepository extends JpaRepository<Adhesion, Long> {
+public interface AdhesionRepository extends JpaRepository<Adhesion, Long>, JpaSpecificationExecutor<Adhesion> {
 
 
     List<Adhesion> findByActiviteNom(String nom);
@@ -18,5 +20,8 @@ public interface AdhesionRepository extends JpaRepository<Adhesion, Long> {
     Page<Adhesion> findByActiviteNom(String nom, Pageable pageable);
 
     Page<Adhesion> findByActiviteId(Long id, Pageable pageable);
+
+    @Query("select distinct adhesion.statutActuel from Adhesion adhesion where adhesion.statutActuel is not null order by adhesion.statutActuel")
+    List<String> findDistinctStatuses();
 
 }

--- a/app/src/main/java/com/wild/corp/adhesion/services/AdhesionServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/AdhesionServices.java
@@ -10,6 +10,8 @@ import com.wild.corp.adhesion.utils.Status;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -120,6 +122,21 @@ public class AdhesionServices {
         List<Adhesion> adhesions = adhesionRepository.findAll();
 
         return adhesions.stream().map(adhesion -> reduceAdhesion(adhesion)).toList();
+    }
+
+    public Page<AdhesionLite> getAllLite(String section, Pageable pageable) {
+        String[] sections = section.split("#", 2);
+        Page<Adhesion> adhesions;
+
+        if (sections.length == 2 && sections[0].equals("activite")) {
+            adhesions = adhesionRepository.findByActiviteNom(sections[1], pageable);
+        } else if (sections.length == 2 && sections[0].equals("horaire")) {
+            adhesions = adhesionRepository.findByActiviteId(Long.parseLong(sections[1]), pageable);
+        } else {
+            adhesions = adhesionRepository.findAll(pageable);
+        }
+
+        return adhesions.map(this::reduceAdhesion);
     }
 
 

--- a/app/src/main/java/com/wild/corp/adhesion/services/AdhesionServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/AdhesionServices.java
@@ -12,7 +12,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -85,6 +90,8 @@ public class AdhesionServices {
 
     private AdhesionLite reduceAdhesion(Adhesion adhesion) {
         return AdhesionLite.builder().id(adhesion.getId())
+                .tarif(adhesion.getTarif())
+                .position(adhesion.getPosition())
                 .adherent(AdherentLite.builder()
                         .id(adhesion.getAdherent().getId())
                         .nomPrenom((Objects.equals(adhesion.getAdherent().getNom(), "") ? "zzzz" : adhesion.getAdherent().getNom()) + (Objects.equals(adhesion.getAdherent().getPrenom(), "") ? "zzzz" : adhesion.getAdherent().getPrenom()))
@@ -118,25 +125,85 @@ public class AdhesionServices {
                 .build();
     }
 
+    public List<String> getStatuses() {
+        LinkedHashSet<String> statuses = Arrays.stream(Status.values())
+                .map(value -> value.label)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        statuses.addAll(adhesionRepository.findDistinctStatuses());
+        return List.copyOf(statuses);
+    }
+
     public List<AdhesionLite> getAllLite() {
         List<Adhesion> adhesions = adhesionRepository.findAll();
 
         return adhesions.stream().map(adhesion -> reduceAdhesion(adhesion)).toList();
     }
 
-    public Page<AdhesionLite> getAllLite(String section, Pageable pageable) {
+    public Page<AdhesionLite> getAllLite(String section, String search, String status,
+                                         Boolean paymentValidated, Boolean documentsValidated,
+                                         Boolean flagged, Pageable pageable) {
+        Specification<Adhesion> specification = (root, query, criteriaBuilder) -> criteriaBuilder.conjunction();
         String[] sections = section.split("#", 2);
-        Page<Adhesion> adhesions;
 
         if (sections.length == 2 && sections[0].equals("activite")) {
-            adhesions = adhesionRepository.findByActiviteNom(sections[1], pageable);
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("activite").get("nom"), sections[1]));
         } else if (sections.length == 2 && sections[0].equals("horaire")) {
-            adhesions = adhesionRepository.findByActiviteId(Long.parseLong(sections[1]), pageable);
-        } else {
-            adhesions = adhesionRepository.findAll(pageable);
+            Long activiteId = Long.parseLong(sections[1]);
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("activite").get("id"), activiteId));
         }
 
-        return adhesions.map(this::reduceAdhesion);
+        if (StringUtils.hasText(search)) {
+            String searchPattern = toLikePattern(search);
+            specification = specification.and((root, query, criteriaBuilder) -> {
+                Join<Adhesion, Adherent> adherent = root.join("adherent", JoinType.LEFT);
+                Join<Adherent, User> user = adherent.join("user", JoinType.LEFT);
+                Join<Adherent, Adherent> representant = adherent.join("representant", JoinType.LEFT);
+                Join<Adherent, User> representantUser = representant.join("user", JoinType.LEFT);
+
+                var fullName = criteriaBuilder.lower(criteriaBuilder.concat(
+                        criteriaBuilder.concat(adherent.<String>get("nom"), " "),
+                        adherent.<String>get("prenom")));
+
+                return criteriaBuilder.or(
+                        criteriaBuilder.like(criteriaBuilder.lower(adherent.get("nom")), searchPattern, '\\'),
+                        criteriaBuilder.like(criteriaBuilder.lower(adherent.get("prenom")), searchPattern, '\\'),
+                        criteriaBuilder.like(fullName, searchPattern, '\\'),
+                        criteriaBuilder.like(criteriaBuilder.lower(user.get("username")), searchPattern, '\\'),
+                        criteriaBuilder.like(criteriaBuilder.lower(representantUser.get("username")), searchPattern, '\\'),
+                        criteriaBuilder.like(criteriaBuilder.lower(adherent.get("adresse")), searchPattern, '\\'),
+                        criteriaBuilder.like(criteriaBuilder.lower(adherent.get("ville")), searchPattern, '\\')
+                );
+            });
+        }
+
+        if (StringUtils.hasText(status)) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("statutActuel"), status));
+        }
+        if (paymentValidated != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("validPaiementSecretariat"), paymentValidated));
+        }
+        if (documentsValidated != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("validDocumentSecretariat"), documentsValidated));
+        }
+        if (flagged != null) {
+            specification = specification.and((root, query, criteriaBuilder) ->
+                    criteriaBuilder.equal(root.get("flag"), flagged));
+        }
+
+        return adhesionRepository.findAll(specification, pageable).map(this::reduceAdhesion);
+    }
+
+    private String toLikePattern(String value) {
+        String escapedValue = value.trim().toLowerCase(Locale.ROOT)
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        return "%" + escapedValue + "%";
     }
 
 

--- a/client/src/app/_services/adhesion.service.ts
+++ b/client/src/app/_services/adhesion.service.ts
@@ -6,6 +6,14 @@ import { Accord, Activite, Adhesion, Paiement } from '../models';
 
 const API_URL = environment.server+'/adhesion/';
 
+export interface Page<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -84,6 +92,14 @@ export class AdhesionService {
     return this.http.get<Adhesion[]>(API_URL+"liteBysection", {params, responseType: 'json' });
   }
 
+  getPage(sections: string, page: number, size: number): Observable<Page<Adhesion>> {
+    const params = new HttpParams()
+      .set('sections', sections)
+      .set('page', page)
+      .set('size', size);
+    return this.http.get<Page<Adhesion>>(API_URL + "page", {params, responseType: 'json'});
+  }
+
   updateDejaLicencie(adhesionId : number, dejaLicencie:boolean): Observable<any> {
     let params = new HttpParams().set('adhesionId', '' + adhesionId + '').set('dejaLicencie', '' + dejaLicencie + '');
     return this.http.put(API_URL+"updateDejaLicencie", {}, {params, responseType: 'json' });
@@ -117,5 +133,4 @@ export class AdhesionService {
     return this.http.post<Adhesion>(API_URL+"savePaiement", paiement, {params, responseType: 'json' });
   }
 }
-
 

--- a/client/src/app/_services/adhesion.service.ts
+++ b/client/src/app/_services/adhesion.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams} from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { Accord, Activite, Adhesion, Paiement } from '../models';
+import { Accord, Activite, Adhesion, AdhesionLite, Paiement } from '../models';
 
 const API_URL = environment.server+'/adhesion/';
 
@@ -12,6 +12,18 @@ export interface Page<T> {
   totalPages: number;
   number: number;
   size: number;
+}
+
+export interface AdhesionPageQuery {
+  sections: string;
+  page: number;
+  size: number;
+  search?: string;
+  status?: string;
+  paymentValidated?: boolean | null;
+  documentsValidated?: boolean | null;
+  flagged?: boolean | null;
+  sort?: string;
 }
 
 @Injectable({
@@ -92,12 +104,36 @@ export class AdhesionService {
     return this.http.get<Adhesion[]>(API_URL+"liteBysection", {params, responseType: 'json' });
   }
 
-  getPage(sections: string, page: number, size: number): Observable<Page<Adhesion>> {
-    const params = new HttpParams()
-      .set('sections', sections)
-      .set('page', page)
-      .set('size', size);
-    return this.http.get<Page<Adhesion>>(API_URL + "page", {params, responseType: 'json'});
+  getPage(query: AdhesionPageQuery): Observable<Page<AdhesionLite>> {
+    let params = new HttpParams()
+      .set('sections', query.sections)
+      .set('page', query.page)
+      .set('size', query.size);
+
+    if (query.search) {
+      params = params.set('search', query.search);
+    }
+    if (query.status) {
+      params = params.set('status', query.status);
+    }
+    if (query.paymentValidated !== null && query.paymentValidated !== undefined) {
+      params = params.set('paymentValidated', query.paymentValidated);
+    }
+    if (query.documentsValidated !== null && query.documentsValidated !== undefined) {
+      params = params.set('documentsValidated', query.documentsValidated);
+    }
+    if (query.flagged !== null && query.flagged !== undefined) {
+      params = params.set('flagged', query.flagged);
+    }
+    if (query.sort) {
+      params = params.set('sort', query.sort);
+    }
+
+    return this.http.get<Page<AdhesionLite>>(API_URL + "page", {params, responseType: 'json'});
+  }
+
+  getStatuses(): Observable<string[]> {
+    return this.http.get<string[]>(API_URL + "statuses", {responseType: 'json'});
   }
 
   updateDejaLicencie(adhesionId : number, dejaLicencie:boolean): Observable<any> {
@@ -133,4 +169,3 @@ export class AdhesionService {
     return this.http.post<Adhesion>(API_URL+"savePaiement", paiement, {params, responseType: 'json' });
   }
 }
-

--- a/client/src/app/models/activiteLite.ts
+++ b/client/src/app/models/activiteLite.ts
@@ -8,6 +8,7 @@ export class ActiviteLite {
   horaire!: string;
   lien!: string;
   salle!: string;
+  groupe!: string;
   adherents!: AdherentLite[];
 
   constructor(){

--- a/client/src/app/models/adherentLite.ts
+++ b/client/src/app/models/adherentLite.ts
@@ -1,5 +1,6 @@
 import { Accord } from "./accord";
 import { AdhesionLite } from "./adhesionLite";
+import { Notification } from "./notification";
 
 export class AdherentLite {
   id!: number;
@@ -27,13 +28,17 @@ export class AdherentLite {
   adhesions!: AdhesionLite[]
   lieuNaissance!: string;
   naissance!: string;
-  tribuId!: number;
+  tribuId!: string;
   tribuSize!: number;
+  derniereModifs!: Notification[];
+  derniereVisites!: Notification[];
   constructor() {
 
     this.accords = [];
 
     this.adhesions = []
+    this.derniereModifs = [];
+    this.derniereVisites = [];
   }
 
 

--- a/client/src/app/models/adhesionLite.ts
+++ b/client/src/app/models/adhesionLite.ts
@@ -3,31 +3,36 @@ import { Accord } from "./accord";
 import { ActiviteLite } from "./activiteLite";
 import { AdherentLite } from "./adherentLite";
 import { Paiement } from "./paiement";
+import { Notification } from "./notification";
 
 export class AdhesionLite {
 
   id!: number;
   tarif!: number;
-  activite!: ActiviteLite | undefined
-  adherentNom!: AdherentLite | undefined
+  activite!: ActiviteLite;
+  adherent!: AdherentLite;
   paiements!: Paiement[];
-  typeReglement!: String;
-  dateReglement!: String;
-  dateChangementStatut!: string
-  statutActuel!: String;
-  remarqueSecretariat!: String;
+  typeReglement!: string;
+  dateReglement!: string;
+  dateChangementStatut!: string;
+  statutActuel!: string;
+  remarqueSecretariat!: string;
   inscrit!: boolean;
   flag!: boolean;
-  mineur!: boolean;
+  dejaLicencie?: boolean;
   validPaiementSecretariat!: boolean;
   validDocumentSecretariat!: boolean;
   blocage!: boolean;
   accords!: Accord[];
+  derniereModifs!: Notification[];
+  derniereVisites!: Notification[];
   
   constructor() {
 
     this.paiements = [];
 
     this.accords = [];
+    this.derniereModifs = [];
+    this.derniereVisites = [];
   }
 }

--- a/client/src/app/models/index.ts
+++ b/client/src/app/models/index.ts
@@ -2,6 +2,7 @@
 export * from './activiteNm1';
 export * from './adherent';
 export * from './adhesion';
+export * from './adhesionLite';
 export * from './email';
 export * from './tribu';
 export * from './accord';

--- a/client/src/app/page/adhesions/adhesions.component.css
+++ b/client/src/app/page/adhesions/adhesions.component.css
@@ -1,14 +1,312 @@
-.truncate{
-    word-wrap: break-word;
-    max-width: 150px;
+:host {
+  display: block;
+  background: #f4f7f6;
+  min-height: calc(100vh - 64px);
 }
 
+.adhesions-page {
+  max-width: 1800px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  color: #18322b;
+}
 
+.table-toolbar,
+.toolbar-page-controls,
+.cell-actions,
+.member-name {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
 
-  .ligne:hover{
-    background-color: rgba(188, 219, 205, 255)!important;
+.muted,
+.status-cell small,
+.member-cell small {
+  color: #6a7b76;
+}
+
+.section-picker .btn {
+  max-width: 420px;
+  white-space: normal;
+}
+
+.section-menu {
+  max-height: 70vh;
+  min-width: 320px;
+  overflow-y: auto;
+}
+
+.section-group {
+  border-top: 1px solid #e7ecea;
+}
+
+.section-name {
+  font-weight: 700;
+}
+
+.schedule-name {
+  padding-left: 2rem;
+  font-size: .9rem;
+}
+
+.filter-panel {
+  display: grid;
+  grid-template-columns: minmax(260px, 2fr) minmax(220px, 1.4fr) repeat(3, minmax(130px, 1fr)) auto;
+  gap: .75rem;
+  align-items: end;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid #dce6e2;
+  border-radius: .75rem;
+  box-shadow: 0 4px 18px rgba(22, 58, 48, .06);
+}
+
+.filter-field label,
+.table-toolbar label {
+  display: block;
+  margin-bottom: .3rem;
+  color: #425d55;
+  font-size: .78rem;
+  font-weight: 700;
+}
+
+.reset-button {
+  height: 38px;
+}
+
+.table-toolbar {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding: .85rem 0 .6rem;
+  color: #526861;
+  font-size: .9rem;
+}
+
+.toolbar-section-picker {
+  flex: 0 0 auto;
+}
+
+.toolbar-section-picker .btn {
+  width: auto;
+  white-space: nowrap;
+}
+
+.toolbar-results {
+  flex: 1 0 auto;
+  white-space: nowrap;
+}
+
+.toolbar-page-controls {
+  flex: 0 0 auto;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.table-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin: 0;
+}
+
+.table-toolbar select {
+  width: auto;
+}
+
+.page-counter {
+  color: #29483f;
+  font-weight: 700;
+}
+
+.loading-label {
+  color: #26715f;
+}
+
+.adhesion-table-wrapper {
+  background: #fff;
+  border: 1px solid #dce6e2;
+  border-radius: .75rem;
+  box-shadow: 0 4px 18px rgba(22, 58, 48, .06);
+}
+
+.adhesion-table {
+  min-width: 1250px;
+  margin: 0;
+  font-size: .88rem;
+}
+
+.adhesion-table thead th {
+  padding: .85rem .75rem;
+  background: #eaf2ef;
+  border-bottom: 1px solid #ccdbd6;
+  color: #29483f;
+  font-size: .76rem;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.adhesion-table td {
+  padding: .85rem .75rem;
+  border-color: #edf1ef;
+  vertical-align: top;
+}
+
+.adhesion-table tbody tr:hover {
+  background: #f7fbf9;
+}
+
+.sort-button,
+.icon-action {
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+}
+
+.sort-button {
+  font: inherit;
+  text-transform: inherit;
+}
+
+.sort-button:hover {
+  color: #0d6efd;
+}
+
+.activity-cell,
+.member-cell,
+.status-cell {
+  min-width: 170px;
+}
+
+.activity-cell span,
+.member-cell > span,
+.member-cell > a,
+.member-cell > small,
+.status-cell small {
+  display: block;
+  margin-top: .2rem;
+}
+
+.member-cell {
+  min-width: 235px;
+}
+
+.member-cell a {
+  overflow-wrap: anywhere;
+}
+
+.payment-cell,
+.documents-cell {
+  min-width: 225px;
+}
+
+.detail-line {
+  margin-bottom: .28rem;
+}
+
+.detail-line small {
+  display: block;
+  color: #6a7b76;
+}
+
+.cell-actions {
+  justify-content: flex-start;
+  margin-top: .6rem;
+}
+
+.total-amount {
+  margin-right: auto;
+  font-weight: 700;
+}
+
+.icon-action {
+  min-width: 1.55rem;
+  font-size: 1.15rem;
+  opacity: .42;
+  cursor: pointer;
+}
+
+.icon-action:hover,
+.icon-action.active,
+.icon-action.attention {
+  opacity: 1;
+}
+
+.icon-action.success.active,
+.green {
+  color: #198754;
+}
+
+.icon-action.warning.active,
+.icon-action.attention,
+.orange {
+  color: #dc6b19;
+}
+
+.icon-action:disabled {
+  cursor: default;
+}
+
+.status-cell select {
+  min-width: 210px;
+}
+
+.note-cell {
+  min-width: 190px;
+}
+
+.note-cell textarea {
+  min-width: 175px;
+  resize: vertical;
+}
+
+.tracking-cell {
+  min-width: 105px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.tracking-cell .icon-action {
+  margin: 0 .25rem;
+}
+
+.empty-state {
+  padding: 3rem !important;
+  color: #63756f;
+  text-align: center;
+}
+
+@media (max-width: 1200px) {
+  .filter-panel {
+    grid-template-columns: repeat(3, 1fr);
   }
 
-  .colorRed{
-    color: red;
+  .search-field,
+  .status-filter {
+    grid-column: span 2;
   }
+}
+
+@media (max-width: 700px) {
+  .adhesions-page {
+    padding: 1rem .65rem;
+  }
+
+  .filter-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .search-field,
+  .status-filter {
+    grid-column: auto;
+  }
+
+  .section-picker .btn,
+  .section-menu {
+    width: 100%;
+    min-width: 0;
+  }
+
+}

--- a/client/src/app/page/adhesions/adhesions.component.html
+++ b/client/src/app/page/adhesions/adhesions.component.html
@@ -7,13 +7,13 @@
           {{visuelselection.length >0?visuelselection:'Activité'}}
         </button>
         <div *ngIf="activites.length > 0" ngbDropdownMenu aria-labelledby="dropdownBasic1">
-          <a ngbDropdownItem (click)="choixSection = 'Toutes';  getAdhesion(); visuelselection = 'Toutes les adhésions'">
+          <a ngbDropdownItem (click)="choixSection = 'Toutes'; getAdhesion(true); visuelselection = 'Toutes les adhésions'">
             Toutes</a>
           <div *ngFor="let activite of activites  | orderBy:'nom':false" class="ligne pointer">
-            <a ngbDropdownItem (click)="choixSection = 'activite#'+activite.nom;  getAdhesion(); visuelselection = activite.nom+'-Tous horaires'">
+            <a ngbDropdownItem (click)="choixSection = 'activite#'+activite.nom; getAdhesion(true); visuelselection = activite.nom+'-Tous horaires'">
               <b>{{activite.nom}}</b></a>
             <div *ngFor="let horaire of activite.horaires">
-              <a ngbDropdownItem (click)="choixSection = 'horaire#'+horaire.id; getAdhesion(); visuelselection = activite.nom+'-'+horaire.nom">
+              <a ngbDropdownItem (click)="choixSection = 'horaire#'+horaire.id; getAdhesion(true); visuelselection = activite.nom+'-'+horaire.nom">
                 {{horaire.nom}}</a>
             </div>
           </div>
@@ -23,7 +23,7 @@
 
     </div>
     <div class="btn-group btn-group-sm col-4 center" role="group">
-     <p> {{(adhesions | filterAdhesionBy:validPaiementSecretariat:validDocumentSecretariat:statutActuel:flag).length}} adhésions listées</p>
+     <p>{{totalElements}} adhésions au total</p>
     </div>
 
 </div>
@@ -271,6 +271,16 @@
     </tr>
   </tbody>
 </table>
+
+<ngb-pagination *ngIf="totalElements > pageSize"
+  class="d-flex justify-content-center"
+  [(page)]="page"
+  [pageSize]="pageSize"
+  [collectionSize]="totalElements"
+  [maxSize]="7"
+  [rotate]="true"
+  (pageChange)="getAdhesion()">
+</ngb-pagination>
 
 
 

--- a/client/src/app/page/adhesions/adhesions.component.html
+++ b/client/src/app/page/adhesions/adhesions.component.html
@@ -1,295 +1,188 @@
-<div class="row">
+<section class="adhesions-page">
+  <div class="filter-panel">
+    <div class="filter-field search-field">
+      <label for="adhesion-search">Recherche</label>
+      <input id="adhesion-search" type="search" class="form-control" [(ngModel)]="searchTerm"
+        (ngModelChange)="onSearchChange($event)" placeholder="Nom, prénom, e-mail ou adresse">
+    </div>
 
+    <div class="filter-field status-filter">
+      <label for="status-filter">Statut</label>
+      <select id="status-filter" class="form-select" [(ngModel)]="statutActuel" (ngModelChange)="applyFilters()">
+        <option value="">Tous les statuts</option>
+        <option *ngFor="let status of statusOptions" [value]="status">{{status}}</option>
+      </select>
+    </div>
 
-    <div class="btn-group btn-group-sm col-4" role="group">
-      <div ngbDropdown class="d-inline-block larger">
-        <button type="button" class="btn btn-primary larger" id="dropdownBasic1" ngbDropdownToggle>
-          {{visuelselection.length >0?visuelselection:'Activité'}}
-        </button>
-        <div *ngIf="activites.length > 0" ngbDropdownMenu aria-labelledby="dropdownBasic1">
-          <a ngbDropdownItem (click)="choixSection = 'Toutes'; getAdhesion(true); visuelselection = 'Toutes les adhésions'">
-            Toutes</a>
-          <div *ngFor="let activite of activites  | orderBy:'nom':false" class="ligne pointer">
-            <a ngbDropdownItem (click)="choixSection = 'activite#'+activite.nom; getAdhesion(true); visuelselection = activite.nom+'-Tous horaires'">
-              <b>{{activite.nom}}</b></a>
-            <div *ngFor="let horaire of activite.horaires">
-              <a ngbDropdownItem (click)="choixSection = 'horaire#'+horaire.id; getAdhesion(true); visuelselection = activite.nom+'-'+horaire.nom">
-                {{horaire.nom}}</a>
-            </div>
-          </div>
+    <div class="filter-field">
+      <label for="payment-filter">Paiement</label>
+      <select id="payment-filter" class="form-select" [(ngModel)]="validPaiementSecretariat" (ngModelChange)="applyFilters()">
+        <option [ngValue]="null">Tous</option>
+        <option [ngValue]="true">Validé</option>
+        <option [ngValue]="false">À vérifier</option>
+      </select>
+    </div>
+
+    <div class="filter-field">
+      <label for="documents-filter">Documents</label>
+      <select id="documents-filter" class="form-select" [(ngModel)]="validDocumentSecretariat" (ngModelChange)="applyFilters()">
+        <option [ngValue]="null">Tous</option>
+        <option [ngValue]="true">Validés</option>
+        <option [ngValue]="false">À vérifier</option>
+      </select>
+    </div>
+
+    <div class="filter-field">
+      <label for="flag-filter">Signalement</label>
+      <select id="flag-filter" class="form-select" [(ngModel)]="flag" (ngModelChange)="applyFilters()">
+        <option [ngValue]="null">Tous</option>
+        <option [ngValue]="true">Signalés</option>
+        <option [ngValue]="false">Non signalés</option>
+      </select>
+    </div>
+
+    <button type="button" class="btn btn-outline-secondary reset-button" (click)="resetFilters()"
+      [disabled]="!hasActiveFilters">Réinitialiser</button>
+  </div>
+
+  <div class="table-toolbar">
+    <div ngbDropdown class="section-picker toolbar-section-picker">
+      <button type="button" class="btn btn-primary" id="section-filter-button" ngbDropdownToggle>
+        {{visuelselection || 'Choisir une activité'}}
+      </button>
+      <div *ngIf="activites.length > 0" ngbDropdownMenu aria-labelledby="section-filter-button" class="section-menu">
+        <button ngbDropdownItem (click)="selectSection('Toutes', 'Toutes les adhésions')">Toutes les adhésions</button>
+        <div *ngFor="let activite of activites | orderBy:'nom':false" class="section-group">
+          <button ngbDropdownItem class="section-name"
+            (click)="selectSection('activite#' + activite.nom, activite.nom + ' · Tous horaires')">
+            {{activite.nom}}
+          </button>
+          <button *ngFor="let horaire of activite.horaires" ngbDropdownItem class="schedule-name"
+            (click)="selectSection('horaire#' + horaire.id, activite.nom + ' · ' + horaire.nom)">
+            {{horaire.nom}}
+          </button>
         </div>
       </div>
-
-
-    </div>
-    <div class="btn-group btn-group-sm col-4 center" role="group">
-     <p>{{totalElements}} adhésions au total</p>
     </div>
 
-</div>
+    <div class="toolbar-results">
+      <span *ngIf="!loadder">Résultats {{firstResult}}–{{lastResult}} sur {{totalElements}}</span>
+      <span *ngIf="loadder" class="loading-label"><span class="spinner-border spinner-border-sm"></span> Chargement…</span>
+    </div>
 
+    <div class="toolbar-page-controls">
+      <label for="page-size">Lignes par page
+        <select id="page-size" class="form-select form-select-sm" [(ngModel)]="pageSize" (ngModelChange)="onPageSizeChange()">
+          <option *ngFor="let size of pageSizes" [ngValue]="size">{{size}}</option>
+        </select>
+      </label>
+      <span *ngIf="totalPages > 0" class="page-counter">Page {{page}} sur {{totalPages}}</span>
+      <div *ngIf="totalPages > 0" class="btn-group" role="group" aria-label="Pagination des adhésions">
+        <button type="button" class="btn btn-outline-primary btn-sm" [disabled]="page <= 1"
+          (click)="goToPage(page - 1)">Précédente</button>
+        <button type="button" class="btn btn-outline-primary btn-sm" [disabled]="page >= totalPages"
+          (click)="goToPage(page + 1)">Suivante</button>
+      </div>
+    </div>
+  </div>
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th class="center" scope="col truncate">
+  <div class="table-responsive adhesion-table-wrapper">
+    <table class="table adhesion-table">
+      <thead>
+        <tr>
+          <th scope="col"><button class="sort-button" (click)="changeSort('activite.nom')">Activité {{sortIndicator('activite.nom')}}</button></th>
+          <th scope="col"><button class="sort-button" (click)="changeSort('adherent.nom')">Adhérent {{sortIndicator('adherent.nom')}}</button></th>
+          <th scope="col">Paiement</th>
+          <th scope="col">Documents</th>
+          <th scope="col"><button class="sort-button" (click)="changeSort('statutActuel')">Statut {{sortIndicator('statutActuel')}}</button></th>
+          <th scope="col">Remarque</th>
+          <th scope="col" class="text-center">Suivi</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngIf="loadder && adhesions.length === 0">
+          <td colspan="7" class="empty-state"><span class="spinner-border text-primary"></span><br>Chargement des adhésions…</td>
+        </tr>
+        <tr *ngIf="!loadder && adhesions.length === 0">
+          <td colspan="7" class="empty-state"><strong>Aucune adhésion trouvée</strong><br>Modifiez les filtres ou la section sélectionnée.</td>
+        </tr>
+        <tr *ngFor="let adhesion of adhesions; trackBy: trackByAdhesion">
+          <td class="activity-cell">
+            <strong>{{adhesion.activite.nom}}</strong>
+            <span>{{adhesion.activite.horaire}}</span>
+          </td>
 
-
-      </th>
-      <th class="center" scope="col">
-        Adhérent
-      </th>
-      <th class="center" scope="col">
-
-        <div ngbDropdown id="icon">
-          <div id="dropdownBasic1" ngbDropdownToggle>
-            Paiement <fa-icon [ngClass]="validPaiementSecretariat!=null?'colorRed':''" [icon]="faFilter" container="body"></fa-icon>
-          </div>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1" style="float:right;">
-            <button ngbDropdownItem (click)="validPaiementSecretariat=true">Effectué</button>
-            <button ngbDropdownItem (click)="validPaiementSecretariat=false">Manquant</button>
-            <button ngbDropdownItem (click)="validPaiementSecretariat=null">Pas de filtre</button>
-          </div>
-        </div>
-
-      </th>
-
-
-
-      <th class="center" scope="col">
-
-
-        <div ngbDropdown id="icon">
-          <div id="dropdownBasic1" ngbDropdownToggle>
-            Accord <fa-icon  [ngClass]="validDocumentSecretariat!=null?'colorRed':''" [icon]="faFilter" container="body"></fa-icon>
-          </div>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1" style="float:right;">
-            <button ngbDropdownItem (click)="validDocumentSecretariat=true">Docs Validés</button>
-            <button ngbDropdownItem (click)="validDocumentSecretariat=false">Docs Manquants</button>
-            <button ngbDropdownItem (click)="validDocumentSecretariat=null">Pas de filtre</button>
-          </div>
-        </div>
-
-      </th>
-
-      <th class="center" scope="col">
-
-        <div ngbDropdown id="icon">
-          <div id="dropdownBasic1" ngbDropdownToggle>
-            Statut <fa-icon  [ngClass]="statutActuel!=''?'colorRed':''" [icon]="faFilter" container="body"></fa-icon>
-          </div>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1" style="float:right;">
-            <button ngbDropdownItem (click)="statutActuel='Attente validation adhérent'">Attente
-              validation
-              adhérent</button>
-            <button ngbDropdownItem (click)="statutActuel='Attente validation secrétariat'">Attente
-              validation secrétariat</button>
-            <button ngbDropdownItem (click)="statutActuel='Attente création licence'">Attente
-              création licence</button>
-            <button ngbDropdownItem
-              (click)="statutActuel='Validée, en attente du certificat médical'">Validée, en attente du
-              certificat médical</button>
-            <button ngbDropdownItem (click)="statutActuel='Validée'">Validée</button>
-            <button ngbDropdownItem (click)="statutActuel='Licence FFBB à compléter'">Licence FFBB à compléter</button>
-            <button ngbDropdownItem (click)="statutActuel='Retour ALOD Basket'">Retour ALOD Basket</button>
-            <button ngbDropdownItem (click)="statutActuel='Licence générée'">Licence générée</button>
-            <button ngbDropdownItem (click)="statutActuel='Retour Comité'">Retour Comité</button>
-            <button ngbDropdownItem (click)="statutActuel='Licence T'">Licence T</button>
-            <button ngbDropdownItem (click)="statutActuel='Attente paiement'">Attente paiement</button>
-            <button ngbDropdownItem (click)="statutActuel='Sur liste d\'attente'">Sur liste
-              d'attente</button>
-            <button ngbDropdownItem (click)="statutActuel='Annulée'">Annulée</button>
-
-
-            <button ngbDropdownItem (click)="statutActuel=''">Pas de filtre</button>
-          </div>
-        </div>
-
-
-
-
-      </th>
-
-
-      <th class="center" scope="col">Remarque</th>
-
-      <th class="center" scope="col">
-
-
-        <div ngbDropdown id="icon">
-          <div id="dropdownBasic1" ngbDropdownToggle>
-            Flag <fa-icon  [ngClass]="flag!=null?'colorRed':''" [icon]="faFilter" container="body"></fa-icon>
-
-          </div>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1" style="float:right;">
-            <button ngbDropdownItem (click)="flag=true">Les flagés</button>
-            <button ngbDropdownItem (click)="flag=false">Les non flagé</button>
-            <button ngbDropdownItem (click)="flag=null">Pas de filtre</button>
-          </div>
-        </div>
-
-
-      </th>
-
-    </tr>
-  </thead>
-  <div *ngIf="loadder" class="spinner-border text-info"></div>
-
-  <tbody *ngIf="adhesions.length > 0">
-    <tr *ngFor="let adhesion of adhesions | filterAdhesionBy:validPaiementSecretariat:validDocumentSecretariat:statutActuel:flag ">
-      <td width="10%" class="truncate">
-        {{adhesion.activite.nom}}<br />{{adhesion.activite.horaire}}
-      </td>
-
-      <td width="20%">
-        {{adhesion.adherent.nom}} {{adhesion.adherent.prenom}} <br />
-        {{adhesion.adherent.emailRepresentant && adhesion.adherent.representant != undefined
-        ?adhesion.adherent.representant.user.username:adhesion.adherent.user.username}} <br />
-        {{adhesion.adherent.naissance | date:'dd-MM-yyyy'}}
-        <fa-icon class="fa-lg pointer" (click)="opennewTab('#/inscription/'+adhesion.adherent.tribu.uuid)"
-          [icon]="faPen"></fa-icon>
-      </td>
-
-
-
-
-      <td width="20%" class="center">
-        <div class="row">
-          <div class="col-8">
-            <div *ngFor="let paiement of adhesion.paiements | orderBy:'id':false">
-              {{paiement.montant}} € en {{paiement.typeReglement}} le {{paiement.dateReglement | date: 'dd/MM/YYYY'}}
+          <td class="member-cell">
+            <div class="member-name">
+              <strong>{{adhesion.adherent.nom}} {{adhesion.adherent.prenom}}</strong>
+              <button type="button" class="icon-action" title="Ouvrir la fiche adhérent"
+                (click)="opennewTab('#/inscription/' + adhesion.adherent.tribuId)"><fa-icon [icon]="faPen"></fa-icon></button>
             </div>
-          </div>
-          <div class="col-4">
-            <fa-icon (click)="updatePaiementSecretariat(adhesion, true); openModal(editProfileModal, adhesion);"
-              [ngClass]="adhesion.validPaiementSecretariat ? 'pointer green fa-2xl' : 'pointer fa-2xl'"
-              [icon]="faCircleCheck"></fa-icon>
-            <fa-icon (click)="updatePaiementSecretariat(adhesion, false); openModal(editProfileModal, adhesion);"
-              [ngClass]="!adhesion.validPaiementSecretariat ? 'pointer orange fa-2xl' : 'pointer fa-2xl'"
-              [icon]="faCircleXmark"></fa-icon>
-            <br />Total de {{ calculSomme(adhesion) }}€
-          </div>
-        </div>
-      </td>
+            <a [href]="'mailto:' + adhesion.adherent.email">{{adhesion.adherent.email}}</a>
+            <span *ngIf="adhesion.adherent.adresse">{{adhesion.adherent.adresse}}</span>
+            <small *ngIf="adhesion.adherent.naissance">Né(e) le {{adhesion.adherent.naissance | date:'dd/MM/yyyy'}}</small>
+          </td>
 
-      <td width="20%">
-        <div class="row">
-          <div class="col-8">
-            <div *ngFor="let accord of adhesion.accords | orderBy:'id':false ">
+          <td class="payment-cell">
+            <div *ngFor="let paiement of adhesion.paiements | orderBy:'id':false" class="detail-line">
+              <strong>{{paiement.montant}} €</strong> · {{paiement.typeReglement}}
+              <small *ngIf="paiement.dateReglement">{{paiement.dateReglement | date:'dd/MM/yyyy'}}</small>
+            </div>
+            <div *ngIf="adhesion.paiements.length === 0" class="muted">Aucun règlement</div>
+            <div class="cell-actions">
+              <span class="total-amount">Total {{calculSomme(adhesion)}} €</span>
+              <button type="button" class="icon-action success" [class.active]="adhesion.validPaiementSecretariat"
+                title="Marquer le paiement comme validé" (click)="updatePaiementSecretariat(adhesion, true)"><fa-icon [icon]="faCircleCheck"></fa-icon></button>
+              <button type="button" class="icon-action warning" [class.active]="!adhesion.validPaiementSecretariat"
+                title="Marquer le paiement comme à vérifier" (click)="updatePaiementSecretariat(adhesion, false)"><fa-icon [icon]="faCircleXmark"></fa-icon></button>
+              <button type="button" class="btn btn-sm btn-outline-primary" (click)="openModal(editProfileModal, adhesion)">Gérer</button>
+            </div>
+          </td>
+
+          <td class="documents-cell">
+            <div *ngFor="let accord of adhesion.accords | orderBy:'id':false" class="detail-line">
+              <fa-icon [ngClass]="accord.etat ? 'green' : 'orange'" [icon]="accord.etat ? faCircleCheck : faCircleXmark"></fa-icon>
               {{accord.nom}}
-              <fa-icon *ngIf="accord.etat == true" class="green" [icon]="faCircleCheck"></fa-icon>
-              <fa-icon *ngIf="accord.etat != true" class="orange" [icon]="faCircleXmark"></fa-icon>
             </div>
-          </div>
-          <div class="col-4">
-            <fa-icon (click)="adhesion.validDocumentSecretariat = true; updateDocumentsSecretariat(adhesion, true)"
-              [ngClass]="adhesion.validDocumentSecretariat ? 'pointer green fa-2xl' : 'pointer fa-2xl'"
-              [icon]="faCircleCheck"></fa-icon>
-            <fa-icon (click)="adhesion.validDocumentSecretariat = false; updateDocumentsSecretariat(adhesion, false)"
-              [ngClass]="!adhesion.validDocumentSecretariat ? 'pointer orange fa-2xl' : 'pointer fa-2xl'"
-              [icon]="faCircleXmark"></fa-icon>
-          </div>
-        </div>
-      </td>
+            <div *ngIf="adhesion.accords.length === 0" class="muted">Aucun document</div>
+            <div class="cell-actions">
+              <button type="button" class="icon-action success" [class.active]="adhesion.validDocumentSecretariat"
+                title="Marquer les documents comme validés" (click)="updateDocumentsSecretariat(adhesion, true)"><fa-icon [icon]="faCircleCheck"></fa-icon></button>
+              <button type="button" class="icon-action warning" [class.active]="!adhesion.validDocumentSecretariat"
+                title="Marquer les documents comme à vérifier" (click)="updateDocumentsSecretariat(adhesion, false)"><fa-icon [icon]="faCircleXmark"></fa-icon></button>
+            </div>
+          </td>
 
+          <td class="status-cell">
+            <select class="form-select form-select-sm" [ngModel]="adhesion.statutActuel"
+              (ngModelChange)="choisirStatut(adhesion, $event)">
+              <option *ngFor="let status of statusesFor(adhesion)" [value]="status">{{status}}</option>
+            </select>
+            <small *ngIf="adhesion.dateChangementStatut">Depuis le {{adhesion.dateChangementStatut | date:'dd/MM/yyyy'}}</small>
+          </td>
 
-      <td width="10%" class="center">
-        <div *ngIf="adhesion.activite.groupe == 'ALOD_G'" ngbDropdown class="d-inline-block">
-          <button [ngClass]="adhesion.statutActuel == 'Validée' ? 'btn-outline-secondary' : 'btn-primary'" type="button" class="btn"
-            id="dropdownBasic1" ngbDropdownToggle>
-            {{adhesion.statutActuel}}
-          </button>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Attente validation adhérent')">Attente validation
-              adhérent</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Attente validation secrétariat')">Attente
-              validation secrétariat</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Attente paiement')">Attente paiement</button>
-            <button ngbDropdownItem
-              (click)="choisirStatut(adhesion,'Validée, en attente du certificat médical')">Validée, en attente du
-              certificat médical</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Sur liste d\'attente')">Sur liste
-              d'attente</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Validée')">Validée</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Annulée')">Annulée</button>
-          </div>
-        </div>
+          <td class="note-cell">
+            <textarea class="form-control" [(ngModel)]="adhesion.remarqueSecretariat" rows="3"
+              placeholder="Ajouter une note…" (blur)="enregistrerRemarque(adhesion)"></textarea>
+          </td>
 
+          <td class="tracking-cell">
+            <button type="button" class="icon-action warning" [class.active]="adhesion.flag"
+              [title]="adhesion.flag ? 'Retirer le signalement' : 'Signaler cette adhésion'"
+              (click)="updateFlag(adhesion, !adhesion.flag)"><fa-icon [icon]="faFlag"></fa-icon></button>
+            <button type="button" class="icon-action" [class.attention]="verifyAdhesion(adhesion)"
+              title="Marquer les modifications de l’adhésion comme vues" [disabled]="!verifyAdhesion(adhesion)"
+              (click)="updateVisiteAdhesion(adhesion)"><fa-icon [icon]="faCircleExclamation"></fa-icon></button>
+            <button type="button" class="icon-action" [class.attention]="verifyAdherent(adhesion)"
+              title="Marquer les modifications de l’adhérent comme vues" [disabled]="!verifyAdherent(adhesion)"
+              (click)="updateVisiteAdherent(adhesion)"><fa-icon [icon]="faCircleUser"></fa-icon></button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
-        <div *ngIf="adhesion.activite.groupe == 'ALOD_B'" ngbDropdown class="d-inline-block">
-          <button [ngClass]="adhesion.statutActuel == 'Licence générée' ? 'btn-outline-secondary' : 'btn-primary'" type="button" class="btn"
-            id="dropdownBasic1" ngbDropdownToggle>
-            {{adhesion.statutActuel}}
-          </button>
-          <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Attente validation adhérent')">Attente validation
-              adhérent</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Attente validation secrétariat')">Attente
-              validation secrétariat</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion, 'Attente création licence')">Attente
-              création licence</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Licence FFBB à compléter')">Licence FFBB à compléter</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Retour ALOD Basket')">Retour ALOD Basket</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Licence générée')">Licence générée</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Retour Comité')">Retour Comité</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Licence T')">Licence T</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Sur liste d\'attente')">Sur liste
-              d'attente</button>
-            <button ngbDropdownItem (click)="choisirStatut(adhesion,'Annulée')">Annulée</button>
-          </div>
-        </div>
-        <div>
-{{adhesion.dateChangementStatut}}
-        </div>
-      </td>
-      <td width="10%">
-        <textarea [(ngModel)]="adhesion.remarqueSecretariat"  rows="2" cols="20"
-          placeholder="Note..." (blur)='enregistrerRemarque(adhesion)'>
-
-          </textarea>
-
-      </td>
-
-      <td width="10%" class="center">
-        <fa-icon (click)="updateFlag(adhesion, !adhesion.flag)" *ngIf="!adhesion.flag" class="pointer fa-2xl"
-          [icon]="faFlag "></fa-icon>
-        <fa-icon (click)="updateFlag(adhesion, !adhesion.flag)" *ngIf="adhesion.flag" class="pointer orange fa-2xl"
-          [icon]="faFlag"></fa-icon>
-
-        <fa-icon *ngIf="!verifyAdhesion(adhesion)" class="pointer fa-2xl" [icon]="faCircleExclamation "></fa-icon>
-        <fa-icon (click)="updateVisiteAdhesion(adhesion)" *ngIf="verifyAdhesion(adhesion)" class="pointer orange fa-2xl"
-          [icon]="faCircleExclamation "></fa-icon>
-
-        <fa-icon *ngIf="!verifyAdherent(adhesion)" class="pointer fa-2xl" [icon]="faCircleUser"></fa-icon>
-        <fa-icon (click)="updateVisiteAdherent(adhesion)" *ngIf="verifyAdherent(adhesion)" class="pointer orange fa-2xl"
-          [icon]="faCircleUser"></fa-icon>
-
-
-      </td>
-
-
-    </tr>
-  </tbody>
-</table>
-
-<ngb-pagination *ngIf="totalElements > pageSize"
-  class="d-flex justify-content-center"
-  [(page)]="page"
-  [pageSize]="pageSize"
-  [collectionSize]="totalElements"
-  [maxSize]="7"
-  [rotate]="true"
-  (pageChange)="getAdhesion()">
-</ngb-pagination>
-
-
-
-
-
-
-
-
-
+</section>
 <ng-template #editProfileModal let-c="close" let-d="dismiss">
   <div class="modal-header">
     <h4 class="modal-title" id="modal-basic-title">Facturation</h4>
@@ -407,7 +300,7 @@
   </div>
   <div class="modal-body">
     Vous êtes sur le point de supprimer l'adhesion de {{selectedAdhesion.adherent.prenom}} au
-    {{selectedAdhesion.activite?.nom}} {{selectedAdhesion.activite?.horaire}}
+    {{selectedAdhesion.activite.nom}} {{selectedAdhesion.activite.horaire}}
 
   </div>
   <div class="modal-footer">

--- a/client/src/app/page/adhesions/adhesions.component.ts
+++ b/client/src/app/page/adhesions/adhesions.component.ts
@@ -65,6 +65,9 @@ export class AdhesionsComponent implements OnInit {
   faFlag = faFlag;
   adhesions: Adhesion[] = [];
   adhesionsCopy: Adhesion[] = [];
+  page = 1;
+  pageSize = 20;
+  totalElements = 0;
 
 
   validPaiementSecretariat:boolean|null=null;
@@ -132,16 +135,19 @@ export class AdhesionsComponent implements OnInit {
 
   loadder: boolean = true
 
-  getAdhesion() {
+  getAdhesion(resetPage: boolean = false) {
+    if (resetPage) {
+      this.page = 1;
+    }
     this.loadder = true
     this.adhesions = []
     this.adhesionsCopy = []
-    this.adhesionService.getAllLiteBysection(this.choixSection).subscribe({
+    this.adhesionService.getPage(this.choixSection, this.page - 1, this.pageSize).subscribe({
       next: (data) => {
-        console.log(data)
-        data.forEach(value => value.nomprenom = value.adherent.nom + value.adherent.prenom)
-        this.adhesions = data;
-        this.adhesionsCopy = data;
+        data.content.forEach(value => value.nomprenom = value.adherent.nom + value.adherent.prenom)
+        this.adhesions = data.content;
+        this.adhesionsCopy = data.content;
+        this.totalElements = data.totalElements;
         this.loadder = false
       },
       error: (error) => {

--- a/client/src/app/page/adhesions/adhesions.component.ts
+++ b/client/src/app/page/adhesions/adhesions.component.ts
@@ -1,46 +1,29 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {
   ActiviteDropDown,
-  Adhesion,
-  AdhesionExcel,
+  AdhesionLite,
   Document,
   HoraireDropDown,
-  Notification,
   Paiement
 } from 'src/app/models';
 import {AdhesionService} from 'src/app/_services/adhesion.service';
 import {
-  faEarth,
-  faBasketball,
-  faFilterCircleXmark,
-  faFilter,
   faPen,
-  faEye,
-  faEnvelope,
   faCircleUser,
   faFlag,
   faCircleXmark,
   faCircleExclamation,
-  faBook,
-  faScaleBalanced,
-  faPencilSquare,
-  faSquarePlus,
   faSquareMinus,
   faCircleCheck,
-  faUserPlus,
-  faL
 } from '@fortawesome/free-solid-svg-icons';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {TokenStorageService} from 'src/app/_services/token-storage.service';
 import {Router} from '@angular/router';
 import {ParamService} from 'src/app/_services/param.service';
 import {ActiviteService} from 'src/app/_services/activite.service';
-import {ExcelService} from 'src/app/_services/excel.service';
-import {FilterAdhesionByPipe} from 'src/app/_helpers/filterAdhesion.pipe';
-import {DatePipe} from '@angular/common';
-
 import {AdherentService} from 'src/app/_services/adherent.service';
 import {ToastrService} from 'ngx-toastr';
+import {Subject, debounceTime, distinctUntilChanged, takeUntil} from 'rxjs';
 
 
 @Component({
@@ -48,32 +31,56 @@ import {ToastrService} from 'ngx-toastr';
   templateUrl: './adhesions.component.html',
   styleUrls: ['./adhesions.component.css']
 })
-export class AdhesionsComponent implements OnInit {
-  faSeedling = faEarth
-  faBasketball = faBasketball
-  faFilterCircleXmark = faFilterCircleXmark
-  faFilter = faFilter
+export class AdhesionsComponent implements OnInit, OnDestroy {
   faCircleUser = faCircleUser
   faCircleExclamation = faCircleExclamation
   faPen = faPen
-  faSquarePlus = faSquarePlus
-  faEye = faEye
-  faEnvelope = faEnvelope;
   faSquareMinus = faSquareMinus;
   faCircleXmark = faCircleXmark;
   faCircleCheck = faCircleCheck;
   faFlag = faFlag;
-  adhesions: Adhesion[] = [];
-  adhesionsCopy: Adhesion[] = [];
+  adhesions: AdhesionLite[] = [];
   page = 1;
   pageSize = 20;
+  readonly pageSizes = [10, 20, 50, 100];
   totalElements = 0;
+  totalPages = 0;
+  searchTerm = '';
+  sortField = 'adherent.nom';
+  sortDirection: 'asc' | 'desc' = 'asc';
 
+  validPaiementSecretariat: boolean | null = null;
+  validDocumentSecretariat: boolean | null = null;
+  statutActuel = '';
+  flag: boolean | null = null;
+  statusOptions: string[] = [];
 
-  validPaiementSecretariat:boolean|null=null;
-  validDocumentSecretariat:boolean|null=null;
-  statutActuel: string = "";
-  flag:boolean|null=null;
+  readonly generalStatuses = [
+    'Attente validation adhérent',
+    'Attente validation secrétariat',
+    'Attente paiement',
+    'Validée, en attente du certificat médical',
+    'Validée groupement sportif',
+    'Sur liste d\'attente',
+    'Validée',
+    'Annulée'
+  ];
+
+  readonly basketStatuses = [
+    'Attente validation adhérent',
+    'Attente validation secrétariat',
+    'Attente création licence',
+    'Licence FFBB à compléter',
+    'Retour ALOD Basket',
+    'Licence générée',
+    'Retour Comité',
+    'Licence T',
+    'Sur liste d\'attente',
+    'Annulée'
+  ];
+
+  private readonly searchChanges = new Subject<string>();
+  private readonly destroy$ = new Subject<void>();
 
 
 
@@ -84,10 +91,7 @@ export class AdhesionsComponent implements OnInit {
 
   constructor(
     private toastr: ToastrService,
-    private datePipe: DatePipe,
     private adherentService: AdherentService,
-    private filterAdhesionBy: FilterAdhesionByPipe,
-    private excelService: ExcelService,
     private activiteService: ActiviteService,
     private adhesionService: AdhesionService,
     private tokenStorageService: TokenStorageService,
@@ -115,7 +119,6 @@ export class AdhesionsComponent implements OnInit {
 
 
   ngOnInit(): void {
-
     if (this.tokenStorageService.getUser().roles) {
       this.showAdmin = this.tokenStorageService.getUser().roles.includes('ROLE_ADMIN');
       this.showSecretaire = this.tokenStorageService.getUser().roles.includes('ROLE_SECRETAIRE');
@@ -128,9 +131,23 @@ export class AdhesionsComponent implements OnInit {
       }
     } else {
       this.router.navigate(['login']);
+      return;
     }
-    this.getAdhesion()
-    this.getActivites()
+
+    this.searchChanges.pipe(
+      debounceTime(350),
+      distinctUntilChanged(),
+      takeUntil(this.destroy$)
+    ).subscribe(() => this.applyFilters());
+
+    this.getAdhesion();
+    this.getActivites();
+    this.getStatuses();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   loadder: boolean = true
@@ -139,22 +156,104 @@ export class AdhesionsComponent implements OnInit {
     if (resetPage) {
       this.page = 1;
     }
-    this.loadder = true
-    this.adhesions = []
-    this.adhesionsCopy = []
-    this.adhesionService.getPage(this.choixSection, this.page - 1, this.pageSize).subscribe({
+    this.loadder = true;
+    this.adhesionService.getPage({
+      sections: this.choixSection,
+      page: this.page - 1,
+      size: this.pageSize,
+      search: this.searchTerm.trim(),
+      status: this.statutActuel,
+      paymentValidated: this.validPaiementSecretariat,
+      documentsValidated: this.validDocumentSecretariat,
+      flagged: this.flag,
+      sort: `${this.sortField},${this.sortDirection}`
+    }).subscribe({
       next: (data) => {
-        data.content.forEach(value => value.nomprenom = value.adherent.nom + value.adherent.prenom)
         this.adhesions = data.content;
-        this.adhesionsCopy = data.content;
         this.totalElements = data.totalElements;
-        this.loadder = false
+        this.totalPages = data.totalPages;
+        this.page = data.number + 1;
+        this.loadder = false;
       },
       error: (error) => {
-        console.log(error)
-        this.showError(error.error.message)
+        console.log(error);
+        this.loadder = false;
+        this.showError(error.error?.message || error.message);
       }
     });
+  }
+
+  onSearchChange(value: string) {
+    this.searchChanges.next(value.trim());
+  }
+
+  applyFilters() {
+    this.getAdhesion(true);
+  }
+
+  resetFilters() {
+    this.searchTerm = '';
+    this.statutActuel = '';
+    this.validPaiementSecretariat = null;
+    this.validDocumentSecretariat = null;
+    this.flag = null;
+    this.getAdhesion(true);
+  }
+
+  selectSection(section: string, label: string) {
+    this.choixSection = section;
+    this.visuelselection = label;
+    this.getAdhesion(true);
+  }
+
+  changeSort(field: string) {
+    if (this.sortField === field) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortField = field;
+      this.sortDirection = 'asc';
+    }
+    this.getAdhesion(true);
+  }
+
+  sortIndicator(field: string): string {
+    if (this.sortField !== field) {
+      return '↕';
+    }
+    return this.sortDirection === 'asc' ? '↑' : '↓';
+  }
+
+  goToPage(targetPage: number) {
+    if (targetPage < 1 || targetPage > this.totalPages || targetPage === this.page) {
+      return;
+    }
+    this.page = targetPage;
+    this.getAdhesion();
+  }
+
+  onPageSizeChange() {
+    this.getAdhesion(true);
+  }
+
+  get firstResult(): number {
+    return this.totalElements === 0 ? 0 : (this.page - 1) * this.pageSize + 1;
+  }
+
+  get lastResult(): number {
+    return Math.min(this.page * this.pageSize, this.totalElements);
+  }
+
+  get hasActiveFilters(): boolean {
+    return !!this.searchTerm.trim() || !!this.statutActuel || this.validPaiementSecretariat !== null
+      || this.validDocumentSecretariat !== null || this.flag !== null;
+  }
+
+  statusesFor(adhesion: AdhesionLite): string[] {
+    return adhesion.activite.groupe === 'ALOD_B' ? this.basketStatuses : this.generalStatuses;
+  }
+
+  trackByAdhesion(index: number, adhesion: AdhesionLite): number {
+    return adhesion.id;
   }
 
   activites: ActiviteDropDown[] = []
@@ -187,13 +286,26 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
+  getStatuses() {
+    this.adhesionService.getStatuses().subscribe({
+      next: statuses => this.statusOptions = statuses,
+      error: error => {
+        console.log(error);
+        this.statusOptions = Array.from(new Set([...this.generalStatuses, ...this.basketStatuses])).sort();
+      }
+    });
+  }
 
-  updateFlag(adhesion: Adhesion, statut: boolean) {
+
+  updateFlag(adhesion: AdhesionLite, statut: boolean) {
     this.adhesionService.updateFlag(adhesion.id, statut).subscribe({
       next: (data) => {
         adhesion.flag = data.flag;
-        adhesion.derniereModifs = data.derniereModifs
-        adhesion.derniereVisites = data.derniereVisites
+        adhesion.derniereModifs = data.derniereModifs || adhesion.derniereModifs;
+        adhesion.derniereVisites = data.derniereVisites || adhesion.derniereVisites;
+        if (this.flag !== null) {
+          this.reloadAfterFilteredMutation();
+        }
       },
       error: (error) => {
         console.log(error)
@@ -202,12 +314,15 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
-  updateDocumentsSecretariat(adhesion: Adhesion, statut: boolean) {
+  updateDocumentsSecretariat(adhesion: AdhesionLite, statut: boolean) {
     this.adhesionService.updateDocumentsSecretariat(adhesion.id, statut).subscribe({
       next: (data) => {
         adhesion.validDocumentSecretariat = data.validDocumentSecretariat;
-        adhesion.derniereModifs = data.derniereModifs
-        adhesion.derniereVisites = data.derniereVisites
+        adhesion.derniereModifs = data.derniereModifs || adhesion.derniereModifs;
+        adhesion.derniereVisites = data.derniereVisites || adhesion.derniereVisites;
+        if (this.validDocumentSecretariat !== null) {
+          this.reloadAfterFilteredMutation();
+        }
       },
       error: (error) => {
         console.log(error)
@@ -217,12 +332,15 @@ export class AdhesionsComponent implements OnInit {
   }
 
 
-  updatePaiementSecretariat(adhesion: Adhesion, statut: boolean) {
+  updatePaiementSecretariat(adhesion: AdhesionLite, statut: boolean) {
     this.adhesionService.updatePaiementSecretariat(adhesion.id, statut).subscribe({
       next: (data) => {
         adhesion.validPaiementSecretariat = data.validPaiementSecretariat;
-        adhesion.derniereModifs = data.derniereModifs
-        adhesion.derniereVisites = data.derniereVisites
+        adhesion.derniereModifs = data.derniereModifs || adhesion.derniereModifs;
+        adhesion.derniereVisites = data.derniereVisites || adhesion.derniereVisites;
+        if (this.validPaiementSecretariat !== null) {
+          this.reloadAfterFilteredMutation();
+        }
       },
       error: (error) => {
         console.log(error)
@@ -231,16 +349,19 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
-  choisirStatut(adhesion: Adhesion, statutActuel: string) {
+  choisirStatut(adhesion: AdhesionLite, statutActuel: string) {
     this.adhesionService.choisirStatut(adhesion.id, statutActuel).subscribe({
       next: (data) => {
         this.showSuccess("Changement de statut de l'adhésion réussie pour l'adhérent " + adhesion.adherent.prenom + " " + adhesion.adherent.nom)
-        adhesion.statutActuel = data.statutActuel;
-        adhesion.derniereModifs = data.derniereModifs
-        adhesion.derniereVisites = data.derniereVisites
+        adhesion.statutActuel = data.statutActuel.toString();
+        adhesion.derniereModifs = data.derniereModifs || adhesion.derniereModifs;
+        adhesion.derniereVisites = data.derniereVisites || adhesion.derniereVisites;
         adhesion.validDocumentSecretariat = data.validDocumentSecretariat
         adhesion.validPaiementSecretariat = data.validPaiementSecretariat
         adhesion.accords = data.accords
+        if (this.statutActuel && adhesion.statutActuel !== this.statutActuel) {
+          this.reloadAfterFilteredMutation();
+        }
       },
       error: (error) => {
         console.log(error)
@@ -253,18 +374,25 @@ export class AdhesionsComponent implements OnInit {
     window.open(page, '_blank');
   }
 
-  enregistrerRemarque(adhesion: Adhesion) {
+  enregistrerRemarque(adhesion: AdhesionLite) {
     this.adhesionService.enregistrerRemarque(adhesion.id, adhesion.remarqueSecretariat).subscribe({
       next: (data) => {
-        adhesion.remarqueSecretariat = data.remarqueSecretariat
-        adhesion.derniereModifs = data.derniereModifs
-        adhesion.derniereVisites = data.derniereVisites
+        adhesion.remarqueSecretariat = data.remarqueSecretariat?.toString() || '';
+        adhesion.derniereModifs = data.derniereModifs || adhesion.derniereModifs;
+        adhesion.derniereVisites = data.derniereVisites || adhesion.derniereVisites;
       },
       error: (error) => {
         console.log(error)
         this.showError(error.error.message)
       }
     });
+  }
+
+  private reloadAfterFilteredMutation() {
+    if (this.adhesions.length === 1 && this.page > 1) {
+      this.page--;
+    }
+    this.getAdhesion();
   }
 
 
@@ -274,12 +402,15 @@ export class AdhesionsComponent implements OnInit {
 
   }
 
-  acceptSupress(adhesion: Adhesion) {
+  acceptSupress(adhesion: AdhesionLite) {
     this.modalService.dismissAll();
     this.adhesionService.deleteAdhesion(adhesion.id).subscribe({
       next: (data) => {
         this.showSuccess("Suppresson de l'adhésion réussie pour l'adhérent " + adhesion.adherent.prenom + " " + adhesion.adherent.nom)
-        this.adhesions = this.adhesions.filter(adh => adh.id != adhesion.id)
+        if (this.adhesions.length === 1 && this.page > 1) {
+          this.page--;
+        }
+        this.getAdhesion();
       },
       error: (error) => {
         console.log(error)
@@ -288,9 +419,9 @@ export class AdhesionsComponent implements OnInit {
     })
   }
 
-  selectedAdhesion: Adhesion = new Adhesion;
+  selectedAdhesion: AdhesionLite = new AdhesionLite();
 
-  openModal(targetModal: any, adhesion: Adhesion) {
+  openModal(targetModal: any, adhesion: AdhesionLite) {
     this.selectedAdhesion = adhesion;
 
     this.modalService.open(targetModal, {
@@ -301,7 +432,7 @@ export class AdhesionsComponent implements OnInit {
 
   }
 
-  dismiss(selectedAdhesion: Adhesion) {
+  dismiss(selectedAdhesion: AdhesionLite) {
     this.modalService.dismissAll();
   }
 
@@ -313,7 +444,7 @@ export class AdhesionsComponent implements OnInit {
     this.modalService.dismissAll();
   }
 
-  retraitPaiement(adhesion: Adhesion, paiementId: number) {
+  retraitPaiement(adhesion: AdhesionLite, paiementId: number) {
     this.adhesionService.deletePaiement(adhesion.id, paiementId).subscribe({
       next: (data) => {
         adhesion.paiements = adhesion.paiements.filter(paiement => paiement.id != paiementId)
@@ -327,7 +458,7 @@ export class AdhesionsComponent implements OnInit {
     adhesion.paiements = adhesion.paiements.filter(paiement => paiement.id != paiementId)
   }
 
-  updatePaiement(adhesion: Adhesion, paiement: Paiement) {
+  updatePaiement(adhesion: AdhesionLite, paiement: Paiement) {
     this.adhesionService.savePaiement(adhesion.id, paiement).subscribe({
       next: (data) => {
         adhesion.paiements = data.paiements
@@ -340,7 +471,7 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
-  addNewPaiement(adhesion: Adhesion) {
+  addNewPaiement(adhesion: AdhesionLite) {
     this.adhesionService.savePaiement(adhesion.id, new Paiement).subscribe({
       next: (data) => {
         adhesion.paiements = data.paiements
@@ -352,8 +483,8 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
-  calculSomme(adhesion: Adhesion): number {
-    return adhesion.paiements.map(paiement => paiement.montant).reduce((a, b) => a + b, 0)
+  calculSomme(adhesion: AdhesionLite): number {
+    return adhesion.paiements.reduce((total, paiement) => total + (paiement.montant || 0), 0);
   }
 
   openEditModal(targetModal: any, doc: Document) {
@@ -376,7 +507,7 @@ export class AdhesionsComponent implements OnInit {
 
 
 
-  updateVisiteAdhesion(adhesion: Adhesion) {
+  updateVisiteAdhesion(adhesion: AdhesionLite) {
     this.adhesionService.addVisite(adhesion.id).subscribe({
       next: (response) => {
         adhesion.derniereModifs = response.derniereModifs
@@ -389,7 +520,7 @@ export class AdhesionsComponent implements OnInit {
     });
   }
 
-  updateVisiteAdherent(adhesion: Adhesion) {
+  updateVisiteAdherent(adhesion: AdhesionLite) {
     this.adherentService.addVisite(adhesion.adherent.id).subscribe({
       next: (response) => {
         adhesion.adherent.derniereModifs = response.derniereModifs
@@ -403,9 +534,10 @@ export class AdhesionsComponent implements OnInit {
   }
 
 
-  verifyAdhesion(adhesion: Adhesion): boolean {
+  verifyAdhesion(adhesion: AdhesionLite): boolean {
 
-    let lastVisite = adhesion.derniereVisites.length > 0 ? adhesion.derniereVisites.reduce(function (r, a) {
+    const visites = adhesion.derniereVisites || [];
+    let lastVisite = visites.length > 0 ? visites.reduce(function (r, a) {
       return r.date > a.date ? r : a;
     }) : undefined
 
@@ -417,9 +549,10 @@ export class AdhesionsComponent implements OnInit {
   }
 
 
-  verifyAdherent(adhesion: Adhesion): boolean {
+  verifyAdherent(adhesion: AdhesionLite): boolean {
 
-    let lastVisite = adhesion.adherent.derniereVisites.length > 0 ? adhesion.adherent?.derniereVisites?.reduce(function (r, a) {
+    const visites = adhesion.adherent.derniereVisites || [];
+    let lastVisite = visites.length > 0 ? visites.reduce(function (r, a) {
       return r.date > a.date ? r : a;
     }) : undefined
 


### PR DESCRIPTION
### Motivation
- Permettre la récupération paginée des adhésions pour éviter de renvoyer toute la collection en une seule requête et améliorer les performances.
- Exposer un endpoint REST compatible Spring Data `Pageable` pour filtrer par section (activité/horaire).
- Adapter l'interface client pour consommer des pages et afficher une navigation paginée côté UI.

### Description
- Ajout d'un endpoint `GET /adhesion/page` acceptant `Pageable` et un paramètre `sections`, avec `@PageableDefault` pour taille 20 et tri par `adherent.nom`/`adherent.prenom` (`AdhesionController`).
- Extension du repository avec signatures pageable: `findByActiviteNom(String, Pageable)` et `findByActiviteId(Long, Pageable)` (`AdhesionRepository`).
- Ajout en service de `getAllLite(String section, Pageable pageable)` qui applique le filtre `activite`/`horaire` ou retourne `findAll(pageable)`, puis mappe les `Adhesion` en `AdhesionLite` (`AdhesionServices`).
- Côté client Angular, ajout d'une interface générique `Page<T>` et de la méthode `getPage(sections, page, size)` dans `AdhesionService` pour appeler `GET /adhesion/page`.
- Adaptation du composant `AdhesionsComponent` pour gérer `page`, `pageSize`, `totalElements`, appeler `getPage(...)` et réinitialiser la page lors du changement de section, et mise à jour du template pour afficher `ngb-pagination` et le nombre total d'adhésions (`adhesions.component.ts` / `adhesions.component.html`).

### Testing
- Exécution des tests backend avec `mvn test` : build et tests unitaires OK (Tests run: 1, Failures: 0, BUILD SUCCESS).
- Construction frontend avec `npm run build -- --configuration development` : build Angular réussi (bundle généré, warnings non bloquants).
- Aucune erreur de compilation détectée après les modifications (vérification locale de compilation et lint basique passée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71bca9e4bc8321b75b4f6065442253)