### PR TITLE
Pagination des adhérents : endpoint Pageable + intégration côté client

### DIFF
--- a/app/src/main/java/com/wild/corp/adhesion/controllers/AdherentController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/AdherentController.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -119,6 +121,14 @@ public class AdherentController {
     public ResponseEntity<?> getAllFlat(Authentication principal) {
         log.info("getAllFlat by " + principal.getName());
         return ResponseEntity.ok(adherentServices.getAllFlat());
+    }
+
+    @GetMapping("/page")
+    @PreAuthorize("hasRole('SECRETAIRE') or hasRole('MODERATOR') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")
+    public ResponseEntity<?> getPage(Authentication principal,
+                                     @PageableDefault(size = 20, sort = {"nom", "prenom"}) Pageable pageable) {
+        log.info("getPage by " + principal.getName());
+        return ResponseEntity.ok(adherentServices.getPage(pageable));
     }
     @GetMapping("/allExportLite")
     @PreAuthorize("hasRole('SECRETAIRE') or hasRole('MODERATOR') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")

--- a/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -460,46 +462,50 @@ public class AdherentServices {
     }
 
     public List<AdherentFlat> getAllFlat() {
-        List<AdherentFlat> adherentFlats = new ArrayList<>();
-        List<Adherent> adherents = adherentRepository.findAll();
-
-        adherents.forEach(adherent -> {
-            AdherentFlat adherentFlat = new AdherentFlat();
-
-
-            StringBuilder adhesions = new StringBuilder();
-            adherent.getAdhesions().forEach(adhesion -> adhesions.append(adhesion.getActivite().getNom() + " " + adhesion.getActivite().getHoraire() + "\n\r"));
-            adherentFlat.setAdhesions(adhesions.toString());
-
-            StringBuilder activitesNm1 = new StringBuilder();
-            adherent.getActivitesNm1().forEach(adhesion -> activitesNm1.append(adhesion.getNom() + " " + adhesion.getHoraire() + "\n\r"));
-            adherentFlat.setActivitesNm1(activitesNm1.toString());
-
-            StringBuilder accords = new StringBuilder();
-            adherent.getAccords().forEach(adhesion -> accords.append(adhesion.getNom() + " " + adhesion.getEtat() + "\n\r"));
-            adherentFlat.setAccords(accords.toString());
-
-
-            adherentFlat.setId(adherent.getId());
-            adherentFlat.setEmail(Boolean.TRUE.equals(adherent.getEmailRepresentant()) && adherent.getRepresentant() != null ? adherent.getRepresentant().getUser().getUsername() : adherent.getUser().getUsername());
-            adherentFlat.setTelephone(Boolean.TRUE.equals(adherent.getTelephoneRepresentant()) && adherent.getRepresentant() != null ? adherent.getRepresentant().getTelephone() : adherent.getTelephone());
-            adherentFlat.setAdresse(Boolean.TRUE.equals(adherent.getAdresseRepresentant()) && adherent.getRepresentant() != null ?
-                    adherent.getRepresentant().getAdresse() + " " + adherent.getRepresentant().getCodePostal() + " " + adherent.getRepresentant().getVille() :
-                    adherent.getAdresse() + " " + adherent.getCodePostal() + " " + adherent.getVille());
-            adherentFlat.setNaissance(adherent.getNaissance());
-            adherentFlat.setPrenom(adherent.getPrenom());
-            adherentFlat.setNom(adherent.getNom());
-            adherentFlat.setNomPrenom((Objects.equals(adherent.getNom(), "") ? "zzzz" : adherent.getNom()) + (Objects.equals(adherent.getPrenom(), "") ? "zzzz" : adherent.getPrenom()));
-            adherentFlat.setLieuNaissance(adherent.getLieuNaissance());
-            adherentFlat.setTribuId(adherent.getTribu().getUuid());
-
-            adherentFlats.add(adherentFlat);
-        });
-
-        return adherentFlats.stream()
+        return adherentRepository.findAll().stream()
+                .map(this::toAdherentFlat)
                 .sorted(Comparator.comparing(AdherentFlat::getNomPrenom))
                 .collect(Collectors.toList());
+    }
 
+    public Page<AdherentFlat> getPage(Pageable pageable) {
+        return adherentRepository.findAll(pageable).map(this::toAdherentFlat);
+    }
+
+    private AdherentFlat toAdherentFlat(Adherent adherent) {
+        AdherentFlat adherentFlat = new AdherentFlat();
+
+        StringBuilder adhesions = new StringBuilder();
+        adherent.getAdhesions().forEach(adhesion -> adhesions.append(adhesion.getActivite().getNom())
+                .append(" ").append(adhesion.getActivite().getHoraire()).append("\n\r"));
+        adherentFlat.setAdhesions(adhesions.toString());
+
+        StringBuilder activitesNm1 = new StringBuilder();
+        adherent.getActivitesNm1().forEach(activite -> activitesNm1.append(activite.getNom())
+                .append(" ").append(activite.getHoraire()).append("\n\r"));
+        adherentFlat.setActivitesNm1(activitesNm1.toString());
+
+        StringBuilder accords = new StringBuilder();
+        adherent.getAccords().forEach(accord -> accords.append(accord.getNom())
+                .append(" ").append(accord.getEtat()).append("\n\r"));
+        adherentFlat.setAccords(accords.toString());
+
+        adherentFlat.setId(adherent.getId());
+        adherentFlat.setEmail(Boolean.TRUE.equals(adherent.getEmailRepresentant()) && adherent.getRepresentant() != null
+                ? adherent.getRepresentant().getUser().getUsername() : adherent.getUser().getUsername());
+        adherentFlat.setTelephone(Boolean.TRUE.equals(adherent.getTelephoneRepresentant()) && adherent.getRepresentant() != null
+                ? adherent.getRepresentant().getTelephone() : adherent.getTelephone());
+        adherentFlat.setAdresse(Boolean.TRUE.equals(adherent.getAdresseRepresentant()) && adherent.getRepresentant() != null
+                ? adherent.getRepresentant().getAdresse() + " " + adherent.getRepresentant().getCodePostal() + " " + adherent.getRepresentant().getVille()
+                : adherent.getAdresse() + " " + adherent.getCodePostal() + " " + adherent.getVille());
+        adherentFlat.setNaissance(adherent.getNaissance());
+        adherentFlat.setPrenom(adherent.getPrenom());
+        adherentFlat.setNom(adherent.getNom());
+        adherentFlat.setNomPrenom((Objects.equals(adherent.getNom(), "") ? "zzzz" : adherent.getNom())
+                + (Objects.equals(adherent.getPrenom(), "") ? "zzzz" : adherent.getPrenom()));
+        adherentFlat.setLieuNaissance(adherent.getLieuNaissance());
+        adherentFlat.setTribuId(adherent.getTribu().getUuid());
+        return adherentFlat;
     }
 
     public List<AdherentLite> getByRole(Long roleId) {

--- a/client/src/app/_services/adherent.service.ts
+++ b/client/src/app/_services/adherent.service.ts
@@ -8,6 +8,14 @@ import {AdherentExport} from "../models/adherentExport";
 
 const API_URL = environment.server+'/adherent/';
 
+export interface AdherentPage {
+  content: AdherentFlat[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -65,6 +73,15 @@ export class AdherentService {
     return this.http.get<AdherentFlat[]>(API_URL + 'allFlat', { responseType: 'json' });
   }
 
+  getPage(page: number, size: number): Observable<AdherentPage> {
+    const params = new HttpParams()
+      .set('page', page)
+      .set('size', size)
+      .set('sort', 'nom,asc')
+      .append('sort', 'prenom,asc');
+    return this.http.get<AdherentPage>(API_URL + 'page', {params, responseType: 'json'});
+  }
+
   getAllExportLite(): Observable<AdherentExport[]> {
     return this.http.get<AdherentExport[]>(API_URL + 'allExportLite', { responseType: 'json' });
   }
@@ -111,5 +128,4 @@ export class AdherentService {
   }
 
 }
-
 

--- a/client/src/app/page/adherents/adherents.component.css
+++ b/client/src/app/page/adherents/adherents.component.css
@@ -1,3 +1,29 @@
 .ligne:hover{
     background-color: rgba(188, 219, 205, 255)!important;
   }
+.table-toolbar,
+.toolbar-page-controls,
+.table-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.table-toolbar {
+  padding: .85rem 0 .6rem;
+  color: #526861;
+}
+
+.toolbar-page-controls {
+  margin-left: auto;
+}
+
+.table-toolbar label {
+  margin: 0;
+  font-size: .85rem;
+  font-weight: 700;
+}
+
+.table-toolbar select {
+  width: auto;
+}

--- a/client/src/app/page/adherents/adherents.component.html
+++ b/client/src/app/page/adherents/adherents.component.html
@@ -66,6 +66,25 @@
 <div class="row">
 
   <div class="col-12 center">
+    <div class="table-toolbar">
+      <span *ngIf="!loadder">Résultats {{firstResult}}–{{lastResult}} sur {{totalElements}}</span>
+      <span *ngIf="loadder"><span class="spinner-border spinner-border-sm"></span> Chargement…</span>
+      <div class="toolbar-page-controls">
+        <label for="adherent-page-size">Lignes par page
+          <select id="adherent-page-size" class="form-select form-select-sm" [(ngModel)]="pageSize"
+            (ngModelChange)="onPageSizeChange()">
+            <option *ngFor="let size of pageSizes" [ngValue]="size">{{size}}</option>
+          </select>
+        </label>
+        <span *ngIf="totalPages > 0">Page {{page}} sur {{totalPages}}</span>
+        <div *ngIf="totalPages > 0" class="btn-group" role="group" aria-label="Pagination des adhérents">
+          <button type="button" class="btn btn-outline-primary btn-sm" [disabled]="page <= 1"
+            (click)="goToPage(page - 1)">Précédente</button>
+          <button type="button" class="btn btn-outline-primary btn-sm" [disabled]="page >= totalPages"
+            (click)="goToPage(page + 1)">Suivante</button>
+        </div>
+      </div>
+    </div>
     <table class="table table-striped">
       <thead>
         <tr>

--- a/client/src/app/page/adherents/adherents.component.ts
+++ b/client/src/app/page/adherents/adherents.component.ts
@@ -33,6 +33,11 @@ export class AdherentsComponent implements OnInit {
   faEnvelope = faEnvelope;
   faPencilSquare = faPencilSquare;
   adherents: AdherentFlat[] = [];
+  page = 1;
+  pageSize = 20;
+  readonly pageSizes = [10, 20, 50, 100];
+  totalElements = 0;
+  totalPages = 0;
 
   loadder:boolean=true
   errorMessage = '';
@@ -71,22 +76,50 @@ export class AdherentsComponent implements OnInit {
     } else {
       this.router.navigate(['login']);
     }
-    this.adherentService.getAllLite().subscribe({
-      next: (data) => {
-        console.log(data)
-        this.adherents = data;
-        this.loadder=false
-
-
-      },
-      error: (error) => {
-        console.log(error)
-        this.showError(error.error.message)
-      }
-    })
+    this.getAdherents();
     this.activiteService.fillObjects(this.activites, this.activitesListe, undefined);
   }
 
+  getAdherents(resetPage: boolean = false) {
+    if (resetPage) {
+      this.page = 1;
+    }
+    this.loadder = true;
+    this.adherentService.getPage(this.page - 1, this.pageSize).subscribe({
+      next: (data) => {
+        this.adherents = data.content;
+        this.totalElements = data.totalElements;
+        this.totalPages = data.totalPages;
+        this.page = data.number + 1;
+        this.loadder = false;
+      },
+      error: (error) => {
+        console.log(error);
+        this.loadder = false;
+        this.showError(error.error?.message || error.message);
+      }
+    });
+  }
+
+  goToPage(targetPage: number) {
+    if (targetPage < 1 || targetPage > this.totalPages || targetPage === this.page) {
+      return;
+    }
+    this.page = targetPage;
+    this.getAdherents();
+  }
+
+  onPageSizeChange() {
+    this.getAdherents(true);
+  }
+
+  get firstResult(): number {
+    return this.totalElements === 0 ? 0 : (this.page - 1) * this.pageSize + 1;
+  }
+
+  get lastResult(): number {
+    return Math.min(this.page * this.pageSize, this.totalElements);
+  }
 
 
 


### PR DESCRIPTION
### Motivation
- Permettre la récupération paginée des adhérents côté backend pour éviter de charger toute la liste en mémoire et s'aligner sur l'implémentation existante pour les `adhesions`.
- Fournir une API compatible Spring Data `Pageable` et une UI qui supporte la navigation entre pages et le changement de taille de page.

### Description
- Ajout d'un nouvel endpoint sécurisé `GET /adherent/page` acceptant un `Pageable` avec un tri par défaut sur `nom,prenom` et qui retourne une `Page<AdherentFlat>` via `AdherentServices.getPage(Pageable)`.
- Refactorisation de la conversion d'un `Adherent` vers `AdherentFlat` dans `AdherentServices` (`toAdherentFlat`) et réutilisation de cette conversion pour l'ancien endpoint non paginé `getAllFlat()`.
- Ajout d'une méthode client Angular `getPage(page,size)` et du modèle `AdherentPage` dans `client/src/app/_services/adherent.service.ts` pour consommer l'endpoint paginé et trier par `nom,prenom`.
- Mise à jour de la page `adherents` pour charger par pages : ajout des contrôles de pagination (numéro de page, taille de page, précédente/suivante), calcul des indices `firstResult`/`lastResult` et adaptation du style HTML/CSS pour afficher la toolbar de pagination.

### Testing
- Exécution de la suite backend avec `mvn test` a réussi (`Tests run: 6, Failures: 0, Errors: 0`).
- Construction du client avec `npm run build -- --configuration development` a produit un build Angular réussi (bundle généré) ; seules des warnings CommonJS habituels sont présents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71ff8e3a44832183d22c7034777e5f)