### PR TITLE
fix(jwt): expliciter le constructeur utilisé par Spring pour JwtUtils

### DIFF
--- a/app/src/main/java/com/wild/corp/adhesion/security/jwt/JwtUtils.java
+++ b/app/src/main/java/com/wild/corp/adhesion/security/jwt/JwtUtils.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ public class JwtUtils {
   private final long jwtExpirationMs;
   private final Clock clock;
 
+  @Autowired
   public JwtUtils(@Value("${server.app.jwtSecret}") String jwtSecret,
                   @Value("${server.app.jwtExpirationMs}") long jwtExpirationMs) {
     this(jwtSecret, jwtExpirationMs, Clock.systemUTC());

--- a/app/src/test/java/com/wild/corp/adhesion/security/jwt/JwtUtilsTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/security/jwt/JwtUtilsTest.java
@@ -3,12 +3,15 @@ package com.wild.corp.adhesion.security.jwt;
 import com.wild.corp.adhesion.models.UserDetails;
 import io.jsonwebtoken.security.WeakKeyException;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +20,20 @@ class JwtUtilsTest {
 
     private static final String SECRET = "a-secure-signing-secret-with-at-least-64-bytes-for-the-HS512-algorithm";
     private static final Instant NOW = Instant.parse("2026-08-03T12:00:00Z");
+
+    @Test
+    void springUsesTheConfiguredConstructor() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("jwt-test", Map.of(
+                    "server.app.jwtSecret", SECRET,
+                    "server.app.jwtExpirationMs", "60000")));
+            context.register(JwtUtils.class);
+
+            context.refresh();
+
+            assertThat(context.getBean(JwtUtils.class)).isNotNull();
+        }
+    }
 
     @Test
     void generatesAndReadsAValidToken() {


### PR DESCRIPTION
### Motivation

- L'application échouait au démarrage avec `Failed to instantiate [com.wild.corp.adhesion.security.jwt.JwtUtils]: No default constructor found` parce que Spring ne savait pas quel constructeur utiliser dans la présence de plusieurs constructeurs.

### Description

- Ajout de `@Autowired` sur le constructeur public de `JwtUtils` pour indiquer explicitement à Spring d'injecter les propriétés `server.app.jwtSecret` et `server.app.jwtExpirationMs` lors de la création du bean (fichier `app/src/main/java/com/wild/corp/adhesion/security/jwt/JwtUtils.java`).
- Ajout d'un test d'intégration minimal `springUsesTheConfiguredConstructor` qui instancie un `AnnotationConfigApplicationContext`, fournit les propriétés via un `MapPropertySource`, enregistre `JwtUtils` et vérifie que le bean peut être récupéré (fichier `app/src/test/java/com/wild/corp/adhesion/security/jwt/JwtUtilsTest.java`).

### Testing

- Exécution de `mvn -Dtest=JwtUtilsTest test` qui a réussi (tous les tests ciblés sont passés).
- Exécution de `mvn test` qui a réussi (tous les tests du module sont passés), et la base de code compile correctement après les modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a721b52a52883218c7709ad74b2e769)