### PR TITLE
Ajoute la gestion des séances et les calendriers Google

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,13 @@ gh auth status
   git push origin HEAD:agent/gestion-seances-calendrier-google
   ```
 
-- Vérifier l'authentification une fois avec `gh auth status`. Si le jeton est
-  invalide, demander à l'utilisateur d'exécuter `gh auth login -h github.com`
-  plutôt que de multiplier les tentatives réseau.
+- Sur macOS, exécuter `gh auth status` avec accès au trousseau système
+  (hors sandbox) dès la première vérification. Une erreur d'authentification
+  depuis l'environnement isolé ne prouve pas qu'un jeton est invalide : elle
+  peut seulement signifier que le trousseau macOS est inaccessible.
+- Ne demander `gh auth login -h github.com` à l'utilisateur qu'après l'échec
+  de cette vérification avec accès au trousseau. Ne pas faire plusieurs
+  tentatives identiques dans le sandbox.
 - Après un push, une seule vérification ciblée suffit :
 
   ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,38 @@
+# AGENTS.md — Projet Adhesion
+
+## Contexte fonctionnel
+
+Adhesion est une application de gestion associative avec un backend Spring Boot et un frontend Angular.
+
+## Conventions techniques
+
+### Backend
+
+- Préserver les routes existantes et leur sécurité ; une nouvelle route doit utiliser les mêmes mécanismes d’authentification
+- Lorsqu’une relation est reçue via l’API, résoudre l’entité gérée en base avant de sauvegarder.
+- Ajouter ou mettre à jour les tests de service pour les règles métier nouvelles.
+
+### Frontend
+
+- Vérifier que les contrôles utilisent des comparateurs adaptés pour les objets sélectionnés.
+- Garder les libellés utilisateur en français.
+
+## Vérification avant livraison
+
+Avant de commiter :
+
+1. Exécuter `git diff --check`.
+2. Construire le frontend avec `npm run build` dans `client/`.
+3. Compiler ou démarrer le backend pour détecter les erreurs de compilation.
+5. Ne jamais ajouter `.DS_Store`, fichiers d’IDE, secrets ou fichiers de configuration locaux au commit.
+
+## Git et pull requests
+
+- Vérifier `git status -sb` avant toute opération.
+- Ne pas inclure de fichiers non liés à la demande.
+- Faire des commits concis et centrés sur une fonctionnalité.
+- Lorsqu’une PR existe déjà, pousser sur sa branche plutôt que d’en créer une nouvelle.
+
 # Développement local
 
 ## Prérequis
@@ -175,10 +210,4 @@ Interprétation :
   erreurs de console, sans captures d'écran, navigation répétée ni inspection
   de stockage local.
 
-### 4. Authentification
 
-Une erreur indiquant qu'un utilisateur est absent traduit généralement une
-connexion à une base neuve ou incorrecte. Vérifier l'URL JDBC configurée et
-le démarrage Hikari avant de modifier le code, de régénérer les données ou de
-réessayer la connexion. Consulter uniquement l'extrait de logs borné ci-dessus
-et ne jamais afficher les secrets, jetons ou valeurs de `.env`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,110 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml down
 Ne pas supprimer les volumes Docker ni arrêter la base PostgreSQL existante
 sur le port `8105` sans demande explicite : elle peut être partagée avec une
 autre session de développement.
+
+## GitHub : pratique fiable et économe
+
+Avant toute publication, vérifier une seule fois le contexte local :
+
+```sh
+git status -sb
+git diff --stat
+gh auth status
+```
+
+- Ne jamais utiliser `git add -A` dans un répertoire de travail mêlant des
+  modifications existantes et une nouvelle tâche. Ajouter explicitement les
+  fichiers de la fonctionnalité concernée.
+- Lire le diff des seuls fichiers à publier et lancer `git diff --check` avant
+  le commit. Exécuter ensuite uniquement les vérifications pertinentes, sans
+  répéter les builds déjà réussis.
+- Pour mettre à jour une PR existante, identifier et pousser sa **branche
+  source**, pas une branche locale de convenance. Exemple pour la PR 48 :
+
+  ```sh
+  git push origin HEAD:agent/gestion-seances-calendrier-google
+  ```
+
+- Vérifier l'authentification une fois avec `gh auth status`. Si le jeton est
+  invalide, demander à l'utilisateur d'exécuter `gh auth login -h github.com`
+  plutôt que de multiplier les tentatives réseau.
+- Après un push, une seule vérification ciblée suffit :
+
+  ```sh
+  git ls-remote --heads origin <branche-source>
+  ```
+
+Pour limiter la consommation de tokens, ne pas relire toute la PR, tous les
+logs CI ou tout l'historique Git lorsqu'un statut, un diff ciblé et la branche
+source répondent déjà à la question. Ne récupérer les commentaires de revue ou
+les logs d'échec CI que si la tâche le demande explicitement.
+
+## Diagnostic local : une passe courte avant toute relance
+
+Les problèmes de Docker, ports, navigateur et base de données sont coûteux à
+diagnostiquer lorsqu'ils sont traités par essais successifs. Appliquer cette
+séquence, dans cet ordre, et s'arrêter dès qu'une preuve est obtenue.
+
+### 1. État connu avant action
+
+Exécuter **une seule fois** les contrôles concis suivants :
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.local.yml ps
+lsof -nP -iTCP:4200 -sTCP:LISTEN
+lsof -nP -iTCP:4201 -sTCP:LISTEN
+lsof -nP -iTCP:8000 -sTCP:LISTEN
+curl --silent --output /dev/null --write-out 'HTTP %{http_code}\n' http://127.0.0.1:8000/activite/all
+```
+
+Interprétation :
+
+- `401` sur l'API signifie que le backend répond mais que la route exige une
+  authentification ; ce n'est pas une panne.
+- Un port occupé ne doit pas être libéré en arrêtant un processus inconnu.
+  Utiliser le port prévu `4201` pour Angular et conserver `4200` intact.
+- Ne lancer `docker compose up --build` que si le JAR ou le Dockerfile a
+  changé. Sinon, utiliser `docker compose ... up -d`.
+
+### 2. Docker et base de données
+
+- Toujours utiliser `docker-compose.local.yml` : il neutralise le volume
+  Ubuntu, publie l'API sur `8000` et évite le conflit PostgreSQL sur `8105`.
+- La base de test existante est accessible depuis le conteneur uniquement via
+  `host.docker.internal:8105`, jamais via `127.0.0.1:8105`.
+- Ne créer le réseau `traefik_web` qu'après avoir constaté explicitement qu'il
+  est absent. Ne pas recréer les volumes ou la base pour résoudre un problème
+  d'authentification.
+- En cas d'échec, consulter d'abord un extrait borné :
+
+  ```sh
+  docker compose -f docker-compose.yml -f docker-compose.local.yml logs --tail=80 app_adhesion
+  ```
+
+  Ne demander des logs plus longs que si les 80 dernières lignes ne montrent
+  pas l'erreur de connexion ou le message de démarrage.
+
+### 3. Interface et navigateur
+
+- Vérifier l'URL et le serveur avant toute inspection navigateur :
+
+  ```sh
+  curl --silent http://127.0.0.1:4201/adhesion/ | head -20
+  ```
+
+  La page doit contenir le titre `ALOD`. Un autre titre indique qu'un autre
+  projet utilise le port ; démarrer Adhesion sur `4201`, sans tuer ce projet.
+- Ne démarrer qu'une seule instance Angular : vérifier le port avec `lsof`
+  avant `npm start`.
+- Utiliser le navigateur seulement si `curl` confirme que la bonne interface
+  est servie mais que le rendu reste incorrect. Lire d'abord le DOM et les
+  erreurs de console, sans captures d'écran, navigation répétée ni inspection
+  de stockage local.
+
+### 4. Authentification
+
+Une erreur indiquant qu'un utilisateur est absent traduit généralement une
+connexion à une base neuve ou incorrecte. Vérifier l'URL JDBC configurée et
+le démarrage Hikari avant de modifier le code, de régénérer les données ou de
+réessayer la connexion. Consulter uniquement l'extrait de logs borné ci-dessus
+et ne jamais afficher les secrets, jetons ou valeurs de `.env`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Développement local
+
+## Prérequis
+
+- Docker Desktop lancé ;
+- Java 21+ et Maven ;
+- Node.js et les dépendances déjà installées dans `client/node_modules` ;
+- un fichier `.env` local, non versionné, renseignant au minimum :
+  `DB_NAME`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`,
+  `JWT_SECRET`, ainsi que les autres variables utilisées par `docker-compose.yml`.
+
+Ne jamais afficher, modifier ou versionner les valeurs de `.env`.
+
+## Configuration Docker locale
+
+Le fichier `docker-compose.local.yml` est la surcharge à toujours utiliser en
+local. Il corrige les différences avec l'environnement Ubuntu de production :
+
+- expose l'API sur `localhost:8000` ;
+- désactive le montage `/home/ubuntu/adhesion`, indisponible sous macOS ;
+- publie la base Docker secondaire sur `localhost:8106` pour ne pas entrer en
+  conflit avec une base existante sur `8105` ;
+- raccorde l'API à la base locale existante sur le port `8105`, via
+  `host.docker.internal` (et non `127.0.0.1`, qui désigne le conteneur lui-même).
+
+Si le réseau partagé n'existe pas, le créer une seule fois :
+
+```sh
+docker network create traefik_web
+```
+
+## Démarrage
+
+Depuis la racine du dépôt :
+
+```sh
+cd app
+mvn package -DskipTests -q
+cd ..
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build
+cd client
+npm start -- --host 127.0.0.1 --port 4201
+```
+
+L'interface est disponible sur `http://localhost:4201/adhesion/`.
+L'API est disponible sur `http://localhost:8000`.
+
+Le port `4200` peut être occupé par une autre application locale : conserver
+le port `4201` pour Adhesion. Une réponse HTTP `401` de l'API sans jeton de
+connexion est attendue et confirme que le serveur répond.
+
+## Vérifications
+
+```sh
+cd app && mvn package -DskipTests -q
+cd ../client && npm run build
+cd .. && docker compose -f docker-compose.yml -f docker-compose.local.yml ps
+```
+
+`mvn test` peut échouer sous le JDK 25 local, car Mockito ne parvient pas à
+attacher son agent. Utiliser Java 21 pour exécuter la suite de tests complète.
+
+## Arrêt
+
+Arrêter le serveur Angular avec `Ctrl+C`, puis depuis la racine :
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.local.yml down
+```
+
+Ne pas supprimer les volumes Docker ni arrêter la base PostgreSQL existante
+sur le port `8105` sans demande explicite : elle peut être partagée avec une
+autre session de développement.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,9 +1,8 @@
 FROM alpine/java:21
 # copy the packaged jar file into our docker image
-COPY ./adhesion.jar /adhesion.jar
-COPY ./application.yml /resources/application.yml
+COPY ./target/adhesion.jar /adhesion.jar
+COPY ./src/main/resources/application.yml /resources/application.yml
 
 # set the startup command to execute the jar
 CMD ["java", "-jar", "/adhesion.jar", "--spring.config.location=/resources/application.yml"]
-
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,6 +23,7 @@
         <jjwt.version>0.13.0</jjwt.version>
         <openapi-generator.version>7.24.0</openapi-generator.version>
         <postgresql.version>42.7.13</postgresql.version>
+        <ical4j.version>4.3.0</ical4j.version>
     </properties>
 
     <dependencies>
@@ -76,6 +77,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mnode.ical4j</groupId>
+            <artifactId>ical4j</artifactId>
+            <version>${ical4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/app/src/main/java/com/wild/corp/adhesion/config/SeanceSchemaMigration.java
+++ b/app/src/main/java/com/wild/corp/adhesion/config/SeanceSchemaMigration.java
@@ -1,0 +1,30 @@
+package com.wild.corp.adhesion.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Hibernate stores {@code ESeance} by ordinal in the existing schema. When a
+ * new status is added, PostgreSQL's generated check constraint must therefore
+ * be widened as well.
+ */
+@Component
+public class SeanceSchemaMigration implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public SeanceSchemaMigration(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        jdbcTemplate.execute("ALTER TABLE seance DROP CONSTRAINT IF EXISTS seance_etat_seance_check");
+        jdbcTemplate.execute("""
+                ALTER TABLE seance
+                ADD CONSTRAINT seance_etat_seance_check CHECK (etat_seance >= 0 AND etat_seance <= 3)
+                """);
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
@@ -86,7 +86,8 @@ ActiviteServices activiteServices;
 			@RequestBody @Valid MiseAJourSeanceRequest request) {
 		return ResponseEntity.ok(SeanceResponse.from(seanceServices.updateSeance(
 				activiteId, seanceId, request.etatSeance(), request.commentaire(), request.commentairePresent(),
-				request.date(), request.heureDebut(), request.horairePresent())));
+				request.date(), request.heureDebut(), request.horairePresent(),
+				request.salleId(), request.sallePresente())));
 	}
 
 	@DeleteMapping("/{activiteId}/seances/{seanceId}")

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
@@ -52,8 +52,9 @@ ActiviteServices activiteServices;
 	@GetMapping("/calendrier")
 	public ResponseEntity<?> getCalendrier(
 			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateDebut,
-			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFin) {
-		return ResponseEntity.ok(seanceServices.getCalendrier(dateDebut, dateFin));
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFin,
+			@RequestParam(required = false) java.util.UUID tribuUuid) {
+		return ResponseEntity.ok(seanceServices.getCalendrier(dateDebut, dateFin, tribuUuid));
 	}
 
 	@GetMapping("/calendrier/google")

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/ActiviteController.java
@@ -1,16 +1,23 @@
 package com.wild.corp.adhesion.controllers;
 
 import com.wild.corp.adhesion.models.Activite;
+import com.wild.corp.adhesion.models.resources.AjoutSeancesRequest;
+import com.wild.corp.adhesion.models.resources.MiseAJourSeanceRequest;
+import com.wild.corp.adhesion.models.resources.SeanceResponse;
 import com.wild.corp.adhesion.services.ActiviteServices;
+import com.wild.corp.adhesion.services.GoogleAgendaServices;
 import com.wild.corp.adhesion.services.SeanceServices;
+import jakarta.validation.Valid;
 import jakarta.websocket.server.PathParam;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +31,8 @@ public class ActiviteController {
 ActiviteServices activiteServices;
 	@Autowired
 	SeanceServices seanceServices;
+	@Autowired
+	GoogleAgendaServices googleAgendaServices;
 	@GetMapping("/all")
 	public ResponseEntity<?> getAll() {
 		return ResponseEntity.ok(activiteServices.getAll());
@@ -38,6 +47,52 @@ ActiviteServices activiteServices;
 	public ResponseEntity<?> getSeancesDuJourForAcivite( @RequestParam(value="activiteId") Long activiteId) {
 		log.info("getAllCours for activite " + activiteId );
 		return ResponseEntity.ok(activiteServices.getSeancesDuJour(activiteId));
+	}
+
+	@GetMapping("/calendrier")
+	public ResponseEntity<?> getCalendrier(
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateDebut,
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFin) {
+		return ResponseEntity.ok(seanceServices.getCalendrier(dateDebut, dateFin));
+	}
+
+	@GetMapping("/calendrier/google")
+	public ResponseEntity<?> getCalendrierGoogle(
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateDebut,
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFin,
+			@RequestParam("source") List<String> sources) {
+		return ResponseEntity.ok(googleAgendaServices.getCalendrier(dateDebut, dateFin, sources));
+	}
+
+	@GetMapping("/{activiteId}/seances")
+	@PreAuthorize("hasRole('USER')")
+	public ResponseEntity<?> getSeances(@PathVariable Long activiteId) {
+		return ResponseEntity.ok(activiteServices.getSeances(activiteId));
+	}
+
+	@PostMapping("/{activiteId}/seances")
+	@PreAuthorize("hasRole('USER')")
+	public ResponseEntity<?> addSeances(@PathVariable Long activiteId,
+			@RequestBody @Valid AjoutSeancesRequest request) {
+		return ResponseEntity.ok(activiteServices.addSeances(
+				activiteId, request.nombreSeances(), request.dateDebut()));
+	}
+
+	@PatchMapping("/{activiteId}/seances/{seanceId}")
+	@PreAuthorize("hasRole('USER')")
+	public ResponseEntity<?> updateSeance(@PathVariable Long activiteId,
+			@PathVariable Long seanceId,
+			@RequestBody @Valid MiseAJourSeanceRequest request) {
+		return ResponseEntity.ok(SeanceResponse.from(seanceServices.updateSeance(
+				activiteId, seanceId, request.etatSeance(), request.commentaire(), request.commentairePresent(),
+				request.date(), request.heureDebut(), request.horairePresent())));
+	}
+
+	@DeleteMapping("/{activiteId}/seances/{seanceId}")
+	@PreAuthorize("hasRole('USER')")
+	public ResponseEntity<Void> deleteSeance(@PathVariable Long activiteId, @PathVariable Long seanceId) {
+		seanceServices.deleteSeance(activiteId, seanceId);
+		return ResponseEntity.noContent().build();
 	}
 
 

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/ParamController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/ParamController.java
@@ -4,10 +4,12 @@ import com.wild.corp.adhesion.models.ParamBoolean;
 import com.wild.corp.adhesion.models.ParamNumber;
 import com.wild.corp.adhesion.models.ParamText;
 import com.wild.corp.adhesion.models.resources.AgendaGoogleConfiguration;
+import com.wild.corp.adhesion.models.resources.SalleConfiguration;
 import com.wild.corp.adhesion.services.GoogleAgendaConfigurationServices;
 import com.wild.corp.adhesion.services.ParamBooleanServices;
 import com.wild.corp.adhesion.services.ParamNumberServices;
 import com.wild.corp.adhesion.services.ParamTextServices;
+import com.wild.corp.adhesion.services.SalleConfigurationServices;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,9 @@ public class ParamController {
 	@Autowired
 	GoogleAgendaConfigurationServices googleAgendaConfigurationServices;
 
+	@Autowired
+	SalleConfigurationServices salleConfigurationServices;
+
 	@GetMapping("/agendas")
 	public ResponseEntity<?> getAgendas() {
 		return ResponseEntity.ok(googleAgendaConfigurationServices.getAll());
@@ -54,6 +59,30 @@ public class ParamController {
 	@PreAuthorize("hasRole('ADMIN')")
 	public ResponseEntity<Void> deleteAgenda(@PathVariable Long agendaId) {
 		googleAgendaConfigurationServices.delete(agendaId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/salles")
+	public ResponseEntity<?> getSalles() {
+		return ResponseEntity.ok(salleConfigurationServices.getAll());
+	}
+
+	@PostMapping("/salles")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<?> createSalle(@RequestBody SalleConfiguration salle) {
+		return ResponseEntity.ok(salleConfigurationServices.create(salle));
+	}
+
+	@PutMapping("/salles/{salleId}")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<?> updateSalle(@PathVariable Long salleId, @RequestBody SalleConfiguration salle) {
+		return ResponseEntity.ok(salleConfigurationServices.update(salleId, salle));
+	}
+
+	@DeleteMapping("/salles/{salleId}")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<Void> deleteSalle(@PathVariable Long salleId) {
+		salleConfigurationServices.delete(salleId);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/app/src/main/java/com/wild/corp/adhesion/controllers/ParamController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/ParamController.java
@@ -3,6 +3,8 @@ package com.wild.corp.adhesion.controllers;
 import com.wild.corp.adhesion.models.ParamBoolean;
 import com.wild.corp.adhesion.models.ParamNumber;
 import com.wild.corp.adhesion.models.ParamText;
+import com.wild.corp.adhesion.models.resources.AgendaGoogleConfiguration;
+import com.wild.corp.adhesion.services.GoogleAgendaConfigurationServices;
 import com.wild.corp.adhesion.services.ParamBooleanServices;
 import com.wild.corp.adhesion.services.ParamNumberServices;
 import com.wild.corp.adhesion.services.ParamTextServices;
@@ -26,6 +28,34 @@ public class ParamController {
 
 	@Autowired
 	ParamNumberServices paramNumberServices;
+
+	@Autowired
+	GoogleAgendaConfigurationServices googleAgendaConfigurationServices;
+
+	@GetMapping("/agendas")
+	public ResponseEntity<?> getAgendas() {
+		return ResponseEntity.ok(googleAgendaConfigurationServices.getAll());
+	}
+
+	@PostMapping("/agendas")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<?> createAgenda(@RequestBody AgendaGoogleConfiguration agenda) {
+		return ResponseEntity.ok(googleAgendaConfigurationServices.create(agenda));
+	}
+
+	@PutMapping("/agendas/{agendaId}")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<?> updateAgenda(@PathVariable Long agendaId,
+			@RequestBody AgendaGoogleConfiguration agenda) {
+		return ResponseEntity.ok(googleAgendaConfigurationServices.update(agendaId, agenda));
+	}
+
+	@DeleteMapping("/agendas/{agendaId}")
+	@PreAuthorize("hasRole('ADMIN')")
+	public ResponseEntity<Void> deleteAgenda(@PathVariable Long agendaId) {
+		googleAgendaConfigurationServices.delete(agendaId);
+		return ResponseEntity.noContent().build();
+	}
 
 	@GetMapping("/allText")
 	public ResponseEntity<?> getAllText() {

--- a/app/src/main/java/com/wild/corp/adhesion/models/Activite.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/Activite.java
@@ -49,7 +49,14 @@ public class Activite {
 
     private String horaire;
 
-    private String salle;
+    @Column(name = "salle")
+    @JsonIgnore
+    private String salleTexte;
+
+    @ManyToOne
+    @JoinColumn(name = "salle_id")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+    private Salle salle;
 
     private Boolean reinscription;
 
@@ -106,5 +113,9 @@ public class Activite {
     @OneToMany(mappedBy = "activite", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     private List<Seance> seances = new ArrayList<>();
+
+    public String getNomSalle() {
+        return salle != null ? salle.getNom() : salleTexte;
+    }
 
 }

--- a/app/src/main/java/com/wild/corp/adhesion/models/ESeance.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/ESeance.java
@@ -3,5 +3,6 @@ package com.wild.corp.adhesion.models;
 public enum ESeance {
   PROGRAMMEE,
   REALISEE,
-  ANNULEE
+  ANNULEE,
+  MODIFIEE
 }

--- a/app/src/main/java/com/wild/corp/adhesion/models/GoogleAgenda.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/GoogleAgenda.java
@@ -1,0 +1,37 @@
+package com.wild.corp.adhesion.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "google_agenda", uniqueConstraints = @UniqueConstraint(columnNames = "source"))
+public class GoogleAgenda {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nom;
+
+    @Column(nullable = false, length = 500)
+    private String source;
+
+    @Column(nullable = false, length = 7)
+    private String couleur;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/Salle.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/Salle.java
@@ -1,0 +1,36 @@
+package com.wild.corp.adhesion.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "salle")
+public class Salle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nom;
+
+    @Column(nullable = false, length = 500)
+    private String adresse;
+
+    @Column(nullable = false, length = 7)
+    private String couleur;
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/Seance.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/Seance.java
@@ -30,6 +30,16 @@ public class Seance {
     @JsonIgnoreProperties({"adhesions", "profs"})
     private Activite activite;
 
+    /**
+     * Salle effectivement prévue pour cette séance. Elle est initialisée avec
+     * la salle de l'activité lors de la planification, puis peut évoluer sans
+     * modifier les autres séances.
+     */
+    @ManyToOne
+    @JoinColumn(name = "salle_id")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+    private Salle salle;
+
     private ESeance etatSeance;
 
     private String causeAnnulation;

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/AgendaGoogleConfiguration.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/AgendaGoogleConfiguration.java
@@ -1,0 +1,9 @@
+package com.wild.corp.adhesion.models.resources;
+
+public record AgendaGoogleConfiguration(
+        Long id,
+        String nom,
+        String source,
+        String couleur
+) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/AjoutSeancesRequest.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/AjoutSeancesRequest.java
@@ -1,0 +1,17 @@
+package com.wild.corp.adhesion.models.resources;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record AjoutSeancesRequest(
+        @NotNull(message = "La date de début est obligatoire")
+        LocalDate dateDebut,
+        @NotNull(message = "Le nombre de séances est obligatoire")
+        @Min(value = 1, message = "Le nombre de séances doit être supérieur à zéro")
+        @Max(value = 200, message = "Le nombre de séances ne peut pas dépasser 200")
+        Integer nombreSeances
+) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/CalendrierGoogleResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/CalendrierGoogleResponse.java
@@ -1,0 +1,9 @@
+package com.wild.corp.adhesion.models.resources;
+
+import java.util.List;
+
+public record CalendrierGoogleResponse(
+        List<EvenementGoogleAgendaResponse> evenements,
+        List<String> erreurs
+) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/EvenementGoogleAgendaResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/EvenementGoogleAgendaResponse.java
@@ -6,9 +6,11 @@ public record EvenementGoogleAgendaResponse(
         String id,
         String titre,
         String lieu,
+        String commentaire,
         LocalDateTime debut,
         LocalDateTime fin,
         boolean journeeEntiere,
-        String agenda
+        String agenda,
+        String agendaSource
 ) {
 }

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/EvenementGoogleAgendaResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/EvenementGoogleAgendaResponse.java
@@ -1,0 +1,14 @@
+package com.wild.corp.adhesion.models.resources;
+
+import java.time.LocalDateTime;
+
+public record EvenementGoogleAgendaResponse(
+        String id,
+        String titre,
+        String lieu,
+        LocalDateTime debut,
+        LocalDateTime fin,
+        boolean journeeEntiere,
+        String agenda
+) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/MiseAJourSeanceRequest.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/MiseAJourSeanceRequest.java
@@ -1,0 +1,17 @@
+package com.wild.corp.adhesion.models.resources;
+
+import com.wild.corp.adhesion.models.ESeance;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record MiseAJourSeanceRequest(
+        ESeance etatSeance,
+        @Size(max = 255) String commentaire,
+        boolean commentairePresent,
+        LocalDate date,
+        LocalTime heureDebut,
+        boolean horairePresent
+) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/MiseAJourSeanceRequest.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/MiseAJourSeanceRequest.java
@@ -12,6 +12,8 @@ public record MiseAJourSeanceRequest(
         boolean commentairePresent,
         LocalDate date,
         LocalTime heureDebut,
-        boolean horairePresent
+        boolean horairePresent,
+        Long salleId,
+        boolean sallePresente
 ) {
 }

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SalleConfiguration.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SalleConfiguration.java
@@ -1,0 +1,8 @@
+package com.wild.corp.adhesion.models.resources;
+
+public record SalleConfiguration(
+        Long id,
+        String nom,
+        String adresse,
+        String couleur) {
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
@@ -1,0 +1,30 @@
+package com.wild.corp.adhesion.models.resources;
+
+import com.wild.corp.adhesion.models.ESeance;
+import com.wild.corp.adhesion.models.Seance;
+
+import java.time.LocalDateTime;
+
+public record SeanceCalendrierResponse(
+        Long id,
+        Long activiteId,
+        String activiteNom,
+        String horaireActivite,
+        String salle,
+        LocalDateTime debut,
+        LocalDateTime fin,
+        ESeance etatSeance
+) {
+    public static SeanceCalendrierResponse from(Seance seance) {
+        return new SeanceCalendrierResponse(
+                seance.getId(),
+                seance.getActivite().getId(),
+                seance.getActivite().getNom(),
+                seance.getActivite().getHoraire(),
+                seance.getActivite().getSalle(),
+                seance.getDebut(),
+                seance.getFin(),
+                seance.getEtatSeance()
+        );
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
@@ -11,17 +11,27 @@ public record SeanceCalendrierResponse(
         String activiteNom,
         String horaireActivite,
         String salle,
+        String adresseSalle,
+        String couleurSalle,
+        String commentaire,
+        String lien,
         LocalDateTime debut,
         LocalDateTime fin,
         ESeance etatSeance
 ) {
     public static SeanceCalendrierResponse from(Seance seance) {
+        var activite = seance.getActivite();
+        var salle = activite.getSalle();
         return new SeanceCalendrierResponse(
                 seance.getId(),
-                seance.getActivite().getId(),
-                seance.getActivite().getNom(),
-                seance.getActivite().getHoraire(),
-                seance.getActivite().getSalle(),
+                activite.getId(),
+                activite.getNom(),
+                activite.getHoraire(),
+                salle != null ? salle.getNom() : activite.getNomSalle(),
+                salle != null ? salle.getAdresse() : null,
+                salle != null ? salle.getCouleur() : null,
+                seance.getCommentaire(),
+                activite.getLien(),
                 seance.getDebut(),
                 seance.getFin(),
                 seance.getEtatSeance()

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceCalendrierResponse.java
@@ -21,13 +21,13 @@ public record SeanceCalendrierResponse(
 ) {
     public static SeanceCalendrierResponse from(Seance seance) {
         var activite = seance.getActivite();
-        var salle = activite.getSalle();
+        var salle = seance.getSalle();
         return new SeanceCalendrierResponse(
                 seance.getId(),
                 activite.getId(),
                 activite.getNom(),
                 activite.getHoraire(),
-                salle != null ? salle.getNom() : activite.getNomSalle(),
+                salle != null ? salle.getNom() : null,
                 salle != null ? salle.getAdresse() : null,
                 salle != null ? salle.getCouleur() : null,
                 seance.getCommentaire(),

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceResponse.java
@@ -1,0 +1,26 @@
+package com.wild.corp.adhesion.models.resources;
+
+import com.wild.corp.adhesion.models.ESeance;
+import com.wild.corp.adhesion.models.Seance;
+
+import java.time.LocalDateTime;
+
+public record SeanceResponse(
+        Long id,
+        ESeance etatSeance,
+        String causeAnnulation,
+        LocalDateTime debut,
+        LocalDateTime fin,
+        String commentaire
+) {
+    public static SeanceResponse from(Seance seance) {
+        return new SeanceResponse(
+                seance.getId(),
+                seance.getEtatSeance(),
+                seance.getCauseAnnulation(),
+                seance.getDebut(),
+                seance.getFin(),
+                seance.getCommentaire()
+        );
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceResponse.java
+++ b/app/src/main/java/com/wild/corp/adhesion/models/resources/SeanceResponse.java
@@ -1,6 +1,7 @@
 package com.wild.corp.adhesion.models.resources;
 
 import com.wild.corp.adhesion.models.ESeance;
+import com.wild.corp.adhesion.models.Salle;
 import com.wild.corp.adhesion.models.Seance;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,8 @@ public record SeanceResponse(
         String causeAnnulation,
         LocalDateTime debut,
         LocalDateTime fin,
-        String commentaire
+        String commentaire,
+        Salle salle
 ) {
     public static SeanceResponse from(Seance seance) {
         return new SeanceResponse(
@@ -20,7 +22,8 @@ public record SeanceResponse(
                 seance.getCauseAnnulation(),
                 seance.getDebut(),
                 seance.getFin(),
-                seance.getCommentaire()
+                seance.getCommentaire(),
+                seance.getSalle()
         );
     }
 }

--- a/app/src/main/java/com/wild/corp/adhesion/repository/GoogleAgendaRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/GoogleAgendaRepository.java
@@ -1,0 +1,17 @@
+package com.wild.corp.adhesion.repository;
+
+import com.wild.corp.adhesion.models.GoogleAgenda;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GoogleAgendaRepository extends JpaRepository<GoogleAgenda, Long> {
+
+    List<GoogleAgenda> findAllByOrderByNomAsc();
+
+    boolean existsBySource(String source);
+
+    boolean existsBySourceAndIdNot(String source, Long id);
+}

--- a/app/src/main/java/com/wild/corp/adhesion/repository/SalleRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/SalleRepository.java
@@ -1,0 +1,13 @@
+package com.wild.corp.adhesion.repository;
+
+import com.wild.corp.adhesion.models.Salle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SalleRepository extends JpaRepository<Salle, Long> {
+
+    List<Salle> findAllByOrderByNomAsc();
+}

--- a/app/src/main/java/com/wild/corp/adhesion/repository/SeanceRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/SeanceRepository.java
@@ -20,6 +20,12 @@ public interface SeanceRepository extends JpaRepository<Seance, Long> {
     List<Seance> findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(
             LocalDateTime debut, LocalDateTime fin);
 
+    @Query("select distinct s from Seance s join s.activite a join a.adhesions ad join ad.adherent h join h.tribu t " +
+            "where t.uuid = :tribuUuid and ad.statutActuel not in :statutsExclus and s.debut >= :debut and s.debut < :fin order by s.debut")
+    List<Seance> findAllByTribuAndStatutNonExcluAndDebutBetweenOrderByDebut(@Param("tribuUuid") java.util.UUID tribuUuid,
+            @Param("statutsExclus") List<String> statutsExclus,
+            @Param("debut") LocalDateTime debut, @Param("fin") LocalDateTime fin);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Seance s set s.etatSeance = :etat where s.id = :id and s.activite.id = :activiteId")
     int updateEtat(@Param("id") Long id, @Param("activiteId") Long activiteId, @Param("etat") ESeance etat);

--- a/app/src/main/java/com/wild/corp/adhesion/repository/SeanceRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/SeanceRepository.java
@@ -1,10 +1,36 @@
 package com.wild.corp.adhesion.repository;
 
 import com.wild.corp.adhesion.models.Seance;
+import com.wild.corp.adhesion.models.ESeance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface SeanceRepository extends JpaRepository<Seance, Long> {
 
+    Optional<Seance> findByIdAndActivite_Id(Long id, Long activiteId);
+
+    List<Seance> findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(
+            LocalDateTime debut, LocalDateTime fin);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Seance s set s.etatSeance = :etat where s.id = :id and s.activite.id = :activiteId")
+    int updateEtat(@Param("id") Long id, @Param("activiteId") Long activiteId, @Param("etat") ESeance etat);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Seance s set s.commentaire = :commentaire where s.id = :id and s.activite.id = :activiteId")
+    int updateCommentaire(@Param("id") Long id, @Param("activiteId") Long activiteId,
+                          @Param("commentaire") String commentaire);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Seance s set s.debut = :debut, s.fin = :fin where s.id = :id and s.activite.id = :activiteId")
+    int updateHoraire(@Param("id") Long id, @Param("activiteId") Long activiteId,
+                      @Param("debut") LocalDateTime debut, @Param("fin") LocalDateTime fin);
 }

--- a/app/src/main/java/com/wild/corp/adhesion/security/WebSecurityConfig.java
+++ b/app/src/main/java/com/wild/corp/adhesion/security/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.wild.corp.adhesion.security;
 import com.wild.corp.adhesion.services.UserDetailsService;
 import com.wild.corp.adhesion.security.jwt.AuthEntryPointJwt;
 import com.wild.corp.adhesion.security.jwt.AuthTokenFilter;
+import jakarta.servlet.DispatcherType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -63,9 +64,11 @@ public class WebSecurityConfig{
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/auth/**").permitAll()
+                        auth.dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
+                                .requestMatchers("/auth/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/param/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/adherent/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/activite/calendrier", "/activite/calendrier/google").permitAll()
                                 .requestMatchers(HttpMethod.OPTIONS,"/**").permitAll()
                                 .requestMatchers("/swagger-ui**").permitAll()
                                 .anyRequest().authenticated()

--- a/app/src/main/java/com/wild/corp/adhesion/services/ActiviteServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/ActiviteServices.java
@@ -4,6 +4,7 @@ import com.wild.corp.adhesion.models.*;
 import com.wild.corp.adhesion.models.resources.SeanceResponse;
 import com.wild.corp.adhesion.repository.ActiviteNm1Repository;
 import com.wild.corp.adhesion.repository.ActiviteRepository;
+import com.wild.corp.adhesion.repository.SalleRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.BeanUtils;
@@ -28,6 +29,8 @@ public class ActiviteServices {
     ActiviteNm1Repository activiteNm1Repository;
     @Autowired
     SeanceServices seanceServices;
+    @Autowired
+    SalleRepository salleRepository;
 
     public List<Seance> getSeancesDuJour(Long activiteId) {
 
@@ -77,13 +80,15 @@ public class ActiviteServices {
     }
 
     public Activite save(Activite activite) {
+        Salle salle = trouverSalle(activite.getSalle());
         if (activite.getId() != null) {
             Activite activiteInDB = activiteRepository.findById(activite.getId()).orElseThrow();
             activiteInDB.getProfs().forEach(adherent -> adherent.getCours().remove(activiteInDB));
 
             BeanUtils.copyProperties(activite, activiteInDB,
                     "id", "adhesions", "sousClassement", "profs", "seances",
-                    "nbAdhesionsEnCours", "nbAdhesionsCompletes", "nbAdhesionsAttente", "montantCollecte");
+                    "nbAdhesionsEnCours", "nbAdhesionsCompletes", "nbAdhesionsAttente", "montantCollecte", "salle");
+            activiteInDB.setSalle(salle);
 
             activiteInDB.setProfs(activite.getProfs().stream()
                     .map(adherent -> adherentServices.getById(adherent.getId()))
@@ -93,8 +98,17 @@ public class ActiviteServices {
             return activiteRepository.save(activiteInDB);
         }
 
+        activite.setSalle(salle);
         seanceServices.fillSeances(activite, 29);
         return activiteRepository.save(activite);
+    }
+
+    private Salle trouverSalle(Salle salle) {
+        if (salle == null || salle.getId() == null) {
+            return null;
+        }
+        return salleRepository.findById(salle.getId())
+                .orElseThrow(() -> new IllegalArgumentException("La salle sélectionnée n'existe plus"));
     }
 
     public Activite addReferent(Long activiteId, Long adherentId) {

--- a/app/src/main/java/com/wild/corp/adhesion/services/ActiviteServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/ActiviteServices.java
@@ -1,16 +1,17 @@
 package com.wild.corp.adhesion.services;
 
 import com.wild.corp.adhesion.models.*;
+import com.wild.corp.adhesion.models.resources.SeanceResponse;
 import com.wild.corp.adhesion.repository.ActiviteNm1Repository;
 import com.wild.corp.adhesion.repository.ActiviteRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -33,6 +34,20 @@ public class ActiviteServices {
         Activite activite = getById(activiteId);
         LocalDate now = LocalDate.now();
         return activite.getSeances().stream().filter(seance -> now.equals(seance.getDebut())).toList();
+    }
+
+    public List<SeanceResponse> getSeances(Long activiteId) {
+        return getById(activiteId).getSeances().stream()
+                .sorted(Comparator.comparing(Seance::getDebut, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(SeanceResponse::from)
+                .toList();
+    }
+
+    public List<SeanceResponse> addSeances(Long activiteId, int nombreSeances, LocalDate dateDebut) {
+        Activite activite = getById(activiteId);
+        seanceServices.addSeances(activite, nombreSeances, dateDebut);
+        activiteRepository.save(activite);
+        return getSeances(activiteId);
     }
     public List<ActiviteNm1> getAllNm1() {
         List<ActiviteNm1> activites = activiteNm1Repository.findAll();
@@ -63,19 +78,23 @@ public class ActiviteServices {
 
     public Activite save(Activite activite) {
         if (activite.getId() != null) {
-            Optional<Activite> activiteInDB = activiteRepository.findById(activite.getId());
-            activiteInDB.ifPresent(value -> value.getProfs().forEach(adherent -> adherent.getCours().remove(value)));
+            Activite activiteInDB = activiteRepository.findById(activite.getId()).orElseThrow();
+            activiteInDB.getProfs().forEach(adherent -> adherent.getCours().remove(activiteInDB));
 
-            activite.setProfs(activite.getProfs().stream().map(adherent -> adherentServices.getById(adherent.getId())).collect(Collectors.toSet()));
-            activite.getProfs().forEach(adherent -> adherent.getCours().add(activite));
-            if(!activite.getJour().equals(activiteInDB.get().getJour())){
-                seanceServices.modifyDay(activite);
-            }
-        }else{
-           seanceServices.fillSeances(activite, 29);
+            BeanUtils.copyProperties(activite, activiteInDB,
+                    "id", "adhesions", "sousClassement", "profs", "seances",
+                    "nbAdhesionsEnCours", "nbAdhesionsCompletes", "nbAdhesionsAttente", "montantCollecte");
+
+            activiteInDB.setProfs(activite.getProfs().stream()
+                    .map(adherent -> adherentServices.getById(adherent.getId()))
+                    .collect(Collectors.toSet()));
+            activiteInDB.getProfs().forEach(adherent -> adherent.getCours().add(activiteInDB));
+
+            return activiteRepository.save(activiteInDB);
         }
 
-        return  activiteRepository.save(activite);
+        seanceServices.fillSeances(activite, 29);
+        return activiteRepository.save(activite);
     }
 
     public Activite addReferent(Long activiteId, Long adherentId) {

--- a/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
@@ -314,7 +314,7 @@ public class AdherentServices {
             adherentsLite.addAll(activite.getSousClassement().stream().map(this::veryReduceAdherent).collect(Collectors.toSet()));
 
             return ActiviteLite.builder().id(activite.getId())
-                    .salle(activite.getSalle())
+                    .salle(activite.getNomSalle())
                     .lien(activite.getLien())
                     .horaire(activite.getHoraire())
                     .nom(activite.getNom())
@@ -688,7 +688,7 @@ public class AdherentServices {
         activiteNm1.setNom(adhesion.getActivite().getNom());
         activiteNm1.setHoraire(adhesion.getActivite().getHoraire());
         activiteNm1.setGroupe(adhesion.getActivite().getGroupe());
-        activiteNm1.setSalle(adhesion.getActivite().getSalle());
+        activiteNm1.setSalle(adhesion.getActivite().getNomSalle());
         activiteNm1.setTarif(adhesion.getActivite().getTarif());
         activiteNm1.setGroupeFiltre(adhesion.getActivite().getGroupeFiltre());
         return activiteNm1;

--- a/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaConfigurationServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaConfigurationServices.java
@@ -1,0 +1,188 @@
+package com.wild.corp.adhesion.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wild.corp.adhesion.models.GoogleAgenda;
+import com.wild.corp.adhesion.models.ParamText;
+import com.wild.corp.adhesion.models.resources.AgendaGoogleConfiguration;
+import com.wild.corp.adhesion.repository.GoogleAgendaRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+public class GoogleAgendaConfigurationServices {
+
+    private static final String PARAMETRE_AGENDAS = "Google_Agendas";
+    private static final int MAX_AGENDAS = 10;
+    private static final String[] COULEURS_PAR_DEFAUT = {
+            "#4285F4", "#DB4437", "#F4B400", "#0F9D58", "#AB47BC",
+            "#00ACC1", "#FF7043", "#5C6BC0", "#9E9D24", "#8D6E63"
+    };
+
+    private final GoogleAgendaRepository googleAgendaRepository;
+    private final ParamTextServices paramTextServices;
+    private final GoogleAgendaServices googleAgendaServices;
+    private final ObjectMapper objectMapper;
+
+    public GoogleAgendaConfigurationServices(GoogleAgendaRepository googleAgendaRepository,
+                                              ParamTextServices paramTextServices,
+                                              GoogleAgendaServices googleAgendaServices,
+                                              ObjectMapper objectMapper) {
+        this.googleAgendaRepository = googleAgendaRepository;
+        this.paramTextServices = paramTextServices;
+        this.googleAgendaServices = googleAgendaServices;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public List<AgendaGoogleConfiguration> getAll() {
+        migrerAncienneConfiguration();
+        return googleAgendaRepository.findAllByOrderByNomAsc().stream()
+                .map(this::toConfiguration)
+                .toList();
+    }
+
+    @Transactional
+    public AgendaGoogleConfiguration create(AgendaGoogleConfiguration configuration) {
+        if (googleAgendaRepository.count() >= MAX_AGENDAS) {
+            throw configurationInvalide("Le nombre d'agendas Google est limité à " + MAX_AGENDAS);
+        }
+        AgendaGoogleConfiguration normalisee = normaliser(configuration);
+        if (googleAgendaRepository.existsBySource(normalisee.source())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Cet agenda Google est déjà configuré");
+        }
+        GoogleAgenda agenda = GoogleAgenda.builder()
+                .nom(normalisee.nom())
+                .source(normalisee.source())
+                .couleur(normalisee.couleur())
+                .build();
+        return toConfiguration(googleAgendaRepository.save(agenda));
+    }
+
+    @Transactional
+    public AgendaGoogleConfiguration update(Long id, AgendaGoogleConfiguration configuration) {
+        GoogleAgenda agenda = googleAgendaRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Agenda Google introuvable"));
+        AgendaGoogleConfiguration normalisee = normaliser(configuration);
+        if (googleAgendaRepository.existsBySourceAndIdNot(normalisee.source(), id)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Cet agenda Google est déjà configuré");
+        }
+        agenda.setNom(normalisee.nom());
+        agenda.setSource(normalisee.source());
+        agenda.setCouleur(normalisee.couleur());
+        return toConfiguration(googleAgendaRepository.save(agenda));
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        GoogleAgenda agenda = googleAgendaRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Agenda Google introuvable"));
+        googleAgendaRepository.delete(agenda);
+    }
+
+    private AgendaGoogleConfiguration normaliser(AgendaGoogleConfiguration configuration) {
+        if (configuration == null || configuration.source() == null || configuration.source().isBlank()) {
+            throw configurationInvalide("L'identifiant public de l'agenda est obligatoire");
+        }
+        String nom = configuration.nom() == null ? "" : configuration.nom().trim();
+        if (nom.isBlank() || nom.length() > 100) {
+            throw configurationInvalide("Le nom de l'agenda est obligatoire et limité à 100 caractères");
+        }
+        String source = googleAgendaServices.extraireIdentifiant(configuration.source());
+        String couleur = configuration.couleur();
+        if (couleur == null || !couleur.matches("#[0-9a-fA-F]{6}")) {
+            throw configurationInvalide("La couleur de l'agenda doit être au format hexadécimal");
+        }
+        return new AgendaGoogleConfiguration(null, nom, source, couleur.toUpperCase(Locale.ROOT));
+    }
+
+    private void migrerAncienneConfiguration() {
+        if (googleAgendaRepository.count() > 0) {
+            return;
+        }
+        String valeur = paramTextServices.getParamValueOrDefault(PARAMETRE_AGENDAS, "").trim();
+        if (valeur.isBlank()) {
+            return;
+        }
+
+        List<AgendaGoogleConfiguration> anciennesConfigurations = lireAncienneConfiguration(valeur);
+        Map<String, GoogleAgenda> agendasUniques = new LinkedHashMap<>();
+        for (int index = 0; index < anciennesConfigurations.size() && index < MAX_AGENDAS; index++) {
+            AgendaGoogleConfiguration ancienne = anciennesConfigurations.get(index);
+            try {
+                String source = googleAgendaServices.extraireIdentifiant(ancienne.source());
+                String nom = ancienne.nom() == null || ancienne.nom().isBlank()
+                        ? nomParDefaut(source, index) : ancienne.nom().trim();
+                String couleur = ancienne.couleur() != null && ancienne.couleur().matches("#[0-9a-fA-F]{6}")
+                        ? ancienne.couleur().toUpperCase(Locale.ROOT)
+                        : COULEURS_PAR_DEFAUT[index % COULEURS_PAR_DEFAUT.length];
+                agendasUniques.putIfAbsent(source, GoogleAgenda.builder()
+                        .nom(nom.substring(0, Math.min(nom.length(), 100)))
+                        .source(source)
+                        .couleur(couleur)
+                        .build());
+            } catch (ResponseStatusException ignored) {
+                // Une ancienne ligne invalide ne doit pas bloquer les autres agendas.
+            }
+        }
+        if (!agendasUniques.isEmpty()) {
+            googleAgendaRepository.saveAll(agendasUniques.values());
+        }
+        paramTextServices.save(ParamText.builder()
+                .paramName(PARAMETRE_AGENDAS)
+                .paramValue("[]")
+                .build());
+    }
+
+    private List<AgendaGoogleConfiguration> lireAncienneConfiguration(String valeur) {
+        List<AgendaGoogleConfiguration> configurations = new ArrayList<>();
+        if (valeur.startsWith("[")) {
+            try {
+                JsonNode racine = objectMapper.readTree(valeur);
+                if (racine.isArray()) {
+                    for (JsonNode noeud : racine) {
+                        configurations.add(new AgendaGoogleConfiguration(
+                                null,
+                                noeud.path("nom").asText(""),
+                                noeud.path("source").asText(""),
+                                noeud.path("couleur").asText("")));
+                    }
+                }
+            } catch (Exception ignored) {
+                return List.of();
+            }
+        } else {
+            String[] sources = valeur.split("\\r?\\n|;");
+            for (int index = 0; index < sources.length; index++) {
+                if (!sources[index].isBlank()) {
+                    configurations.add(new AgendaGoogleConfiguration(
+                            null, "", sources[index].trim(),
+                            COULEURS_PAR_DEFAUT[index % COULEURS_PAR_DEFAUT.length]));
+                }
+            }
+        }
+        return configurations;
+    }
+
+    private String nomParDefaut(String source, int index) {
+        int arobase = source.indexOf('@');
+        return arobase > 0 ? source.substring(0, arobase) : "Agenda Google " + (index + 1);
+    }
+
+    private AgendaGoogleConfiguration toConfiguration(GoogleAgenda agenda) {
+        return new AgendaGoogleConfiguration(
+                agenda.getId(), agenda.getNom(), agenda.getSource(), agenda.getCouleur());
+    }
+
+    private ResponseStatusException configurationInvalide(String message) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaServices.java
@@ -2,6 +2,7 @@ package com.wild.corp.adhesion.services;
 
 import com.wild.corp.adhesion.models.resources.CalendrierGoogleResponse;
 import com.wild.corp.adhesion.models.resources.EvenementGoogleAgendaResponse;
+import lombok.extern.slf4j.Slf4j;
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.model.Period;
 import net.fortuna.ical4j.model.Property;
@@ -38,6 +39,7 @@ import java.util.Locale;
 import java.util.Set;
 
 @Service
+@Slf4j
 public class GoogleAgendaServices {
 
     private static final ZoneId PARIS = ZoneId.of("Europe/Paris");
@@ -75,6 +77,7 @@ public class GoogleAgendaServices {
             try {
                 evenements.addAll(chargerAgenda(agenda, dateDebut, dateFin));
             } catch (Exception exception) {
+                log.warn("Impossible de charger l'agenda Google {} : {}", agenda, exception.getMessage());
                 erreurs.add("Agenda " + nomCourt(agenda) + " : impossible de charger le flux public");
             }
         }
@@ -89,28 +92,40 @@ public class GoogleAgendaServices {
                 .map(Property::getValue).filter(nom -> !nom.isBlank()).orElse(nomCourt(identifiant));
         List<EvenementGoogleAgendaResponse> evenements = new ArrayList<>();
 
-        for (VEvent evenement : calendrier.<VEvent>getComponents()) {
-            if (evenement.getStatus() != null
-                    && Status.VALUE_CANCELLED.equalsIgnoreCase(evenement.getStatus().getValue())) {
+        for (var composant : calendrier.getComponents()) {
+            if (!(composant instanceof VEvent evenement)) {
                 continue;
             }
-            Temporal debutInitial = evenement.getStartDate().map(date -> date.getDate()).orElse(null);
-            if (debutInitial == null) {
-                continue;
-            }
-            boolean journeeEntiere = debutInitial instanceof LocalDate;
-            for (Period<?> occurrence : occurrences(evenement, debutInitial, dateDebut, dateFin)) {
-                LocalDateTime debut = heureLocale(occurrence.getStart());
-                LocalDateTime fin = heureLocale(occurrence.getEnd());
-                if (fin == null || !fin.isAfter(debut)) {
-                    fin = journeeEntiere ? debut.plusDays(1) : debut;
+            try {
+                if (evenement.getStatus() != null
+                        && Status.VALUE_CANCELLED.equalsIgnoreCase(evenement.getStatus().getValue())) {
+                    continue;
                 }
-                String uid = evenement.getUid().map(Property::getValue).orElse("google");
-                String titre = evenement.getSummary() == null || evenement.getSummary().getValue().isBlank()
-                        ? "Événement Google Agenda" : evenement.getSummary().getValue();
-                String lieu = evenement.getLocation() == null ? null : evenement.getLocation().getValue();
-                evenements.add(new EvenementGoogleAgendaResponse(
-                        uid + "@" + debut, titre, lieu, debut, fin, journeeEntiere, nomAgenda));
+                Temporal debutInitial = evenement.getStartDate().map(date -> date.getDate()).orElse(null);
+                if (debutInitial == null) {
+                    continue;
+                }
+                boolean journeeEntiere = debutInitial instanceof LocalDate;
+                for (Period<?> occurrence : occurrences(evenement, debutInitial, dateDebut, dateFin)) {
+                    LocalDateTime debut = heureLocale(occurrence.getStart());
+                    LocalDateTime fin = heureLocale(occurrence.getEnd());
+                    if (fin == null || !fin.isAfter(debut)) {
+                        fin = journeeEntiere ? debut.plusDays(1) : debut;
+                    }
+                    String uid = evenement.getUid().map(Property::getValue).orElse("google");
+                    String titre = evenement.getSummary() == null || evenement.getSummary().getValue().isBlank()
+                            ? "Événement Google Agenda" : evenement.getSummary().getValue();
+                    String lieu = evenement.getLocation() == null ? null : evenement.getLocation().getValue();
+                    String commentaire = evenement.<Property>getProperty("DESCRIPTION")
+                            .map(Property::getValue).filter(description -> !description.isBlank()).orElse(null);
+                    evenements.add(new EvenementGoogleAgendaResponse(
+                            uid + "@" + debut, titre, lieu, commentaire, debut, fin,
+                            journeeEntiere, nomAgenda, identifiant));
+                }
+            } catch (Exception exception) {
+                String uid = evenement.getUid().map(Property::getValue).orElse("sans identifiant");
+                log.warn("Événement {} ignoré dans l'agenda Google {} : {}", uid, identifiant,
+                        exception.getMessage());
             }
         }
         return evenements;

--- a/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/GoogleAgendaServices.java
@@ -1,0 +1,245 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.models.resources.CalendrierGoogleResponse;
+import com.wild.corp.adhesion.models.resources.EvenementGoogleAgendaResponse;
+import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.model.Period;
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Service
+public class GoogleAgendaServices {
+
+    private static final ZoneId PARIS = ZoneId.of("Europe/Paris");
+    private static final int MAX_AGENDAS = 10;
+    private static final int MAX_ICAL_BYTES = 5 * 1024 * 1024;
+    private final HttpClient httpClient;
+
+    public GoogleAgendaServices() {
+        this(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
+    }
+
+    GoogleAgendaServices(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public CalendrierGoogleResponse getCalendrier(LocalDate dateDebut, LocalDate dateFin, List<String> sources) {
+        validerPeriode(dateDebut, dateFin);
+        Set<String> agendas = new LinkedHashSet<>();
+        if (sources != null) {
+            sources.stream().map(this::extraireIdentifiant).filter(id -> !id.isBlank()).forEach(agendas::add);
+        }
+        if (agendas.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Aucun agenda Google public n'est indiqué");
+        }
+        if (agendas.size() > MAX_AGENDAS) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Le nombre d'agendas Google est limité à " + MAX_AGENDAS);
+        }
+
+        List<EvenementGoogleAgendaResponse> evenements = new ArrayList<>();
+        List<String> erreurs = new ArrayList<>();
+        for (String agenda : agendas) {
+            try {
+                evenements.addAll(chargerAgenda(agenda, dateDebut, dateFin));
+            } catch (Exception exception) {
+                erreurs.add("Agenda " + nomCourt(agenda) + " : impossible de charger le flux public");
+            }
+        }
+        evenements.sort(Comparator.comparing(EvenementGoogleAgendaResponse::debut));
+        return new CalendrierGoogleResponse(evenements, erreurs);
+    }
+
+    List<EvenementGoogleAgendaResponse> lireCalendrier(byte[] contenu, String identifiant,
+                                                        LocalDate dateDebut, LocalDate dateFin) throws Exception {
+        var calendrier = new CalendarBuilder().build(new ByteArrayInputStream(contenu));
+        String nomAgenda = calendrier.<Property>getProperty("X-WR-CALNAME")
+                .map(Property::getValue).filter(nom -> !nom.isBlank()).orElse(nomCourt(identifiant));
+        List<EvenementGoogleAgendaResponse> evenements = new ArrayList<>();
+
+        for (VEvent evenement : calendrier.<VEvent>getComponents()) {
+            if (evenement.getStatus() != null
+                    && Status.VALUE_CANCELLED.equalsIgnoreCase(evenement.getStatus().getValue())) {
+                continue;
+            }
+            Temporal debutInitial = evenement.getStartDate().map(date -> date.getDate()).orElse(null);
+            if (debutInitial == null) {
+                continue;
+            }
+            boolean journeeEntiere = debutInitial instanceof LocalDate;
+            for (Period<?> occurrence : occurrences(evenement, debutInitial, dateDebut, dateFin)) {
+                LocalDateTime debut = heureLocale(occurrence.getStart());
+                LocalDateTime fin = heureLocale(occurrence.getEnd());
+                if (fin == null || !fin.isAfter(debut)) {
+                    fin = journeeEntiere ? debut.plusDays(1) : debut;
+                }
+                String uid = evenement.getUid().map(Property::getValue).orElse("google");
+                String titre = evenement.getSummary() == null || evenement.getSummary().getValue().isBlank()
+                        ? "Événement Google Agenda" : evenement.getSummary().getValue();
+                String lieu = evenement.getLocation() == null ? null : evenement.getLocation().getValue();
+                evenements.add(new EvenementGoogleAgendaResponse(
+                        uid + "@" + debut, titre, lieu, debut, fin, journeeEntiere, nomAgenda));
+            }
+        }
+        return evenements;
+    }
+
+    String extraireIdentifiant(String source) {
+        if (source == null || source.isBlank()) {
+            return "";
+        }
+        String valeur = source.trim();
+        if (valeur.startsWith("http://") || valeur.startsWith("https://")) {
+            URI uri;
+            try {
+                uri = URI.create(valeur);
+            } catch (IllegalArgumentException exception) {
+                throw sourceInvalide();
+            }
+            if (!"https".equalsIgnoreCase(uri.getScheme())
+                    || !"calendar.google.com".equalsIgnoreCase(uri.getHost())) {
+                throw sourceInvalide();
+            }
+            String chemin = uri.getRawPath();
+            int ical = chemin.indexOf("/calendar/ical/");
+            if (ical >= 0) {
+                String suite = chemin.substring(ical + "/calendar/ical/".length());
+                int slash = suite.indexOf('/');
+                valeur = URLDecoder.decode(slash < 0 ? suite : suite.substring(0, slash), StandardCharsets.UTF_8);
+            } else {
+                valeur = parametre(uri.getRawQuery(), "src");
+                if (valeur.isBlank()) {
+                    valeur = decoderCid(parametre(uri.getRawQuery(), "cid"));
+                }
+            }
+        }
+        if (valeur.length() > 500 || !valeur.matches("[A-Za-z0-9._%+@#=\\-]+")) {
+            throw sourceInvalide();
+        }
+        return valeur;
+    }
+
+    private List<EvenementGoogleAgendaResponse> chargerAgenda(String identifiant,
+                                                               LocalDate dateDebut, LocalDate dateFin) throws Exception {
+        String idEncode = URLEncoder.encode(identifiant, StandardCharsets.UTF_8).replace("+", "%20");
+        URI uri = URI.create("https://calendar.google.com/calendar/ical/" + idEncode + "/public/basic.ics");
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(12))
+                .header("Accept", "text/calendar")
+                .GET().build();
+        HttpResponse<java.io.InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (response.statusCode() != 200) {
+            response.body().close();
+            throw new IOException("HTTP " + response.statusCode());
+        }
+        byte[] contenu;
+        try (var flux = response.body()) {
+            contenu = flux.readNBytes(MAX_ICAL_BYTES + 1);
+        }
+        if (contenu.length > MAX_ICAL_BYTES) {
+            throw new IOException("Flux iCalendar trop volumineux");
+        }
+        return lireCalendrier(contenu, identifiant, dateDebut, dateFin);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private List<Period<?>> occurrences(VEvent evenement, Temporal exemple,
+                                        LocalDate dateDebut, LocalDate dateFin) {
+        Period periode = periode(exemple, dateDebut, dateFin.plusDays(1));
+        return new ArrayList<>((Set) evenement.calculateRecurrenceSet(periode));
+    }
+
+    private Period<?> periode(Temporal exemple, LocalDate debut, LocalDate finExclusive) {
+        if (exemple instanceof LocalDate) {
+            return new Period<>(debut, finExclusive);
+        }
+        if (exemple instanceof ZonedDateTime date) {
+            return new Period<>(debut.atStartOfDay(date.getZone()), finExclusive.atStartOfDay(date.getZone()));
+        }
+        if (exemple instanceof OffsetDateTime date) {
+            return new Period<>(debut.atStartOfDay().atOffset(date.getOffset()),
+                    finExclusive.atStartOfDay().atOffset(date.getOffset()));
+        }
+        if (exemple instanceof Instant) {
+            return new Period<>(debut.atStartOfDay(PARIS).toInstant(), finExclusive.atStartOfDay(PARIS).toInstant());
+        }
+        return new Period<>(debut.atStartOfDay(), finExclusive.atStartOfDay());
+    }
+
+    private LocalDateTime heureLocale(Temporal valeur) {
+        if (valeur instanceof LocalDate date) return date.atStartOfDay();
+        if (valeur instanceof LocalDateTime dateHeure) return dateHeure;
+        if (valeur instanceof ZonedDateTime dateHeure) return dateHeure.withZoneSameInstant(PARIS).toLocalDateTime();
+        if (valeur instanceof OffsetDateTime dateHeure) return dateHeure.atZoneSameInstant(PARIS).toLocalDateTime();
+        if (valeur instanceof Instant instant) return instant.atZone(PARIS).toLocalDateTime();
+        throw new IllegalArgumentException("Type de date iCalendar non pris en charge");
+    }
+
+    private String parametre(String query, String nom) {
+        if (query == null) return "";
+        for (String parametre : query.split("&")) {
+            int egal = parametre.indexOf('=');
+            if (egal > 0 && URLDecoder.decode(parametre.substring(0, egal), StandardCharsets.UTF_8).equals(nom)) {
+                return URLDecoder.decode(parametre.substring(egal + 1), StandardCharsets.UTF_8);
+            }
+        }
+        return "";
+    }
+
+    private String decoderCid(String cid) {
+        if (cid.isBlank()) return "";
+        try {
+            return new String(Base64.getUrlDecoder().decode(cid), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException exception) {
+            return cid;
+        }
+    }
+
+    private String nomCourt(String identifiant) {
+        int arobase = identifiant.indexOf('@');
+        return arobase > 0 ? identifiant.substring(0, arobase) : identifiant;
+    }
+
+    private void validerPeriode(LocalDate dateDebut, LocalDate dateFin) {
+        if (dateDebut == null || dateFin == null || dateFin.isBefore(dateDebut)
+                || ChronoUnit.DAYS.between(dateDebut, dateFin) > 370) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La période du calendrier est invalide");
+        }
+    }
+
+    private ResponseStatusException sourceInvalide() {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, "Seules les URLs publiques de calendar.google.com sont acceptées");
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/ParamTextServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/ParamTextServices.java
@@ -178,6 +178,12 @@ public class ParamTextServices {
                             "Les inscriptions débuteront à partir du 4 Juin").build());
         }
 
+        if(!paramTextRepository.existsByParamName("Google_Agendas")) {
+            paramTextRepository.save(ParamText.builder()
+                    .paramName("Google_Agendas")
+                    .paramValue("").build());
+        }
+
         if(!paramTextRepository.existsByParamName("Text_Inscription")) {
             paramTextRepository.save(ParamText.builder()
                     .paramName("Text_Inscription")

--- a/app/src/main/java/com/wild/corp/adhesion/services/ParamTextServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/ParamTextServices.java
@@ -30,6 +30,13 @@ public class ParamTextServices {
     public String getParamValue(String paramName){
         return paramTextRepository.findByParamName(paramName).get().getParamValue();
     }
+
+    public String getParamValueOrDefault(String paramName, String valeurParDefaut) {
+        return paramTextRepository.findByParamName(paramName)
+                .map(ParamText::getParamValue)
+                .orElse(valeurParDefaut);
+    }
+
     public ParamText save(ParamText param){
 
         if(paramTextRepository.existsByParamName(param.getParamName())){
@@ -176,12 +183,6 @@ public class ParamTextServices {
                     .paramValue("Bonjour,<br />Bienvenue sur le site des adhésions de l'ALOD<br />" +
                             "Les préinscriptions sont possibles jusqu'au 27 Mai<br />" +
                             "Les inscriptions débuteront à partir du 4 Juin").build());
-        }
-
-        if(!paramTextRepository.existsByParamName("Google_Agendas")) {
-            paramTextRepository.save(ParamText.builder()
-                    .paramName("Google_Agendas")
-                    .paramValue("").build());
         }
 
         if(!paramTextRepository.existsByParamName("Text_Inscription")) {

--- a/app/src/main/java/com/wild/corp/adhesion/services/SalleConfigurationServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/SalleConfigurationServices.java
@@ -1,0 +1,89 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.models.Salle;
+import com.wild.corp.adhesion.models.resources.SalleConfiguration;
+import com.wild.corp.adhesion.repository.SalleRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Locale;
+
+@Service
+public class SalleConfigurationServices {
+
+    private final SalleRepository salleRepository;
+
+    public SalleConfigurationServices(SalleRepository salleRepository) {
+        this.salleRepository = salleRepository;
+    }
+
+    @Transactional
+    public List<SalleConfiguration> getAll() {
+        return salleRepository.findAllByOrderByNomAsc().stream()
+                .map(this::toConfiguration)
+                .toList();
+    }
+
+    @Transactional
+    public SalleConfiguration create(SalleConfiguration configuration) {
+        SalleConfiguration normalisee = normaliser(configuration);
+        Salle salle = Salle.builder()
+                .nom(normalisee.nom())
+                .adresse(normalisee.adresse())
+                .couleur(normalisee.couleur())
+                .build();
+        return toConfiguration(salleRepository.save(salle));
+    }
+
+    @Transactional
+    public SalleConfiguration update(Long id, SalleConfiguration configuration) {
+        Salle salle = salleRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Salle introuvable"));
+        SalleConfiguration normalisee = normaliser(configuration);
+        salle.setNom(normalisee.nom());
+        salle.setAdresse(normalisee.adresse());
+        salle.setCouleur(normalisee.couleur());
+        return toConfiguration(salleRepository.save(salle));
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Salle salle = salleRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Salle introuvable"));
+        salleRepository.delete(salle);
+    }
+
+    private SalleConfiguration normaliser(SalleConfiguration configuration) {
+        if (configuration == null) {
+            throw configurationInvalide("Les informations de la salle sont obligatoires");
+        }
+        String nom = nettoyer(configuration.nom());
+        String adresse = nettoyer(configuration.adresse());
+        String couleur = configuration.couleur();
+        if (nom.isBlank() || nom.length() > 100) {
+            throw configurationInvalide("Le nom de la salle est obligatoire et limité à 100 caractères");
+        }
+        if (adresse.isBlank() || adresse.length() > 500) {
+            throw configurationInvalide("L'adresse de la salle est obligatoire et limitée à 500 caractères");
+        }
+        if (couleur == null || !couleur.matches("#[0-9a-fA-F]{6}")) {
+            throw configurationInvalide("La couleur de la salle doit être au format hexadécimal");
+        }
+        return new SalleConfiguration(null, nom, adresse, couleur.toUpperCase(Locale.ROOT));
+    }
+
+    private String nettoyer(String valeur) {
+        return valeur == null ? "" : valeur.trim();
+    }
+
+    private SalleConfiguration toConfiguration(Salle salle) {
+        return new SalleConfiguration(salle.getId(), salle.getNom(), salle.getAdresse(), salle.getCouleur());
+    }
+
+    private ResponseStatusException configurationInvalide(String message) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+    }
+}

--- a/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
@@ -13,6 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.wild.corp.adhesion.client.vacances.api.DatasetApi;
 import org.wild.corp.adhesion.client.vacances.model.Record;
 import org.wild.corp.adhesion.client.vacances.model.Records;
+import com.wild.corp.adhesion.utils.Status;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -25,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
 
 @Service
@@ -53,6 +55,10 @@ public class SeanceServices {
     }
 
     public List<SeanceCalendrierResponse> getCalendrier(LocalDate dateDebut, LocalDate dateFin) {
+        return getCalendrier(dateDebut, dateFin, null);
+    }
+
+    public List<SeanceCalendrierResponse> getCalendrier(LocalDate dateDebut, LocalDate dateFin, UUID tribuUuid) {
         if (dateDebut == null || dateFin == null || dateFin.isBefore(dateDebut)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La période du calendrier est invalide");
         }
@@ -60,9 +66,13 @@ public class SeanceServices {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La période du calendrier est limitée à un an");
         }
 
-        return seanceRepository
-                .findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(
-                        dateDebut.atStartOfDay(), dateFin.plusDays(1).atStartOfDay())
+        List<Seance> seances = tribuUuid == null
+                ? seanceRepository.findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(dateDebut.atStartOfDay(), dateFin.plusDays(1).atStartOfDay())
+                : seanceRepository.findAllByTribuAndStatutNonExcluAndDebutBetweenOrderByDebut(
+                    tribuUuid,
+                    List.of(Status.LISTE_ATTENTE.label, Status.ANNULEE.label),
+                    dateDebut.atStartOfDay(), dateFin.plusDays(1).atStartOfDay());
+        return seances
                 .stream()
                 .map(SeanceCalendrierResponse::from)
                 .toList();

--- a/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
@@ -1,22 +1,30 @@
 package com.wild.corp.adhesion.services;
 
 import com.wild.corp.adhesion.models.*;
+import com.wild.corp.adhesion.models.resources.SeanceCalendrierResponse;
 import com.wild.corp.adhesion.repository.SeanceRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import org.wild.corp.adhesion.client.vacances.api.DatasetApi;
 import org.wild.corp.adhesion.client.vacances.model.Record;
 import org.wild.corp.adhesion.client.vacances.model.Records;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -36,12 +44,28 @@ public class SeanceServices {
                           @Qualifier("joursFeriesDatasetApi") DatasetApi joursFeriesApi,
                           @Value("${adhesion.calendrier.zone:C}") String zone,
                           @Value("${adhesion.calendrier.vacances-dataset:fr-en-calendrier-scolaire}") String vacancesDataset,
-                          @Value("${adhesion.calendrier.jours-feries-dataset:jours-feries-en-france}") String joursFeriesDataset) {
+                          @Value("${adhesion.calendrier.jours-feries-dataset:jours-ouvres-week-end-feries-france-2010-a-2030}") String joursFeriesDataset) {
         this.vacancesApi = vacancesApi;
         this.joursFeriesApi = joursFeriesApi;
         this.zone = zone;
         this.vacancesDataset = vacancesDataset;
         this.joursFeriesDataset = joursFeriesDataset;
+    }
+
+    public List<SeanceCalendrierResponse> getCalendrier(LocalDate dateDebut, LocalDate dateFin) {
+        if (dateDebut == null || dateFin == null || dateFin.isBefore(dateDebut)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La période du calendrier est invalide");
+        }
+        if (ChronoUnit.DAYS.between(dateDebut, dateFin) > 370) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La période du calendrier est limitée à un an");
+        }
+
+        return seanceRepository
+                .findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(
+                        dateDebut.atStartOfDay(), dateFin.plusDays(1).atStartOfDay())
+                .stream()
+                .map(SeanceCalendrierResponse::from)
+                .toList();
     }
 
     public Seance addFirstSeance(Activite activite, LocalDate date) {
@@ -59,9 +83,7 @@ public class SeanceServices {
 
     /** Creates one session per week, except during holidays for the requested school zone. */
     public void fillSeances(Activite activite, int nbWeeks, String schoolZone, LocalDate from) {
-        if (activite.getJour() == null || activite.getHoraireDebut() == null || activite.getDuree() == null) {
-            throw new IllegalArgumentException("Le jour, l'heure de début et la durée de l'activité sont obligatoires");
-        }
+        validateSchedule(activite);
         if (nbWeeks < 0) {
             throw new IllegalArgumentException("Le nombre de semaines ne peut pas être négatif");
         }
@@ -78,6 +100,61 @@ public class SeanceServices {
             if (!unavailableDates.contains(date)) {
                 activite.getSeances().add(addFirstSeance(activite, date));
             }
+        }
+    }
+
+    /**
+     * Adds the requested number of weekly sessions from a date, skipping unavailable
+     * and already scheduled dates. Unlike {@link #fillSeances(Activite, int, String, LocalDate)},
+     * the number represents sessions rather than a number of calendar weeks.
+     */
+    public List<Seance> addSeances(Activite activite, int nbSeances, LocalDate from) {
+        return addSeances(activite, nbSeances, zone, from);
+    }
+
+    public List<Seance> addSeances(Activite activite, int nbSeances, String schoolZone, LocalDate from) {
+        validateSchedule(activite);
+        if (from == null) {
+            throw new IllegalArgumentException("La date de début est obligatoire");
+        }
+        if (nbSeances <= 0) {
+            throw new IllegalArgumentException("Le nombre de séances doit être supérieur à zéro");
+        }
+
+        LocalDate candidate = from.with(TemporalAdjusters.nextOrSame(activite.getJour()));
+        LocalDate unavailableThrough = candidate.plusWeeks(nbSeances + 52L);
+        Set<LocalDate> unavailableDates = getUnavailableDates(schoolZone, candidate, unavailableThrough);
+        Set<LocalDate> existingDates = activite.getSeances().stream()
+                .filter(seance -> seance.getDebut() != null)
+                .map(seance -> seance.getDebut().toLocalDate())
+                .collect(Collectors.toSet());
+        List<Seance> created = new ArrayList<>();
+
+        while (created.size() < nbSeances) {
+            if (candidate.isAfter(unavailableThrough)) {
+                LocalDate nextRangeStart = unavailableThrough.plusDays(1);
+                unavailableThrough = unavailableThrough.plusWeeks(nbSeances + 52L);
+                unavailableDates.addAll(getUnavailableDates(schoolZone, nextRangeStart, unavailableThrough));
+            }
+
+            if (!unavailableDates.contains(candidate) && !existingDates.contains(candidate)) {
+                Seance seance = addFirstSeance(activite, candidate);
+                activite.getSeances().add(seance);
+                created.add(seance);
+                existingDates.add(candidate);
+            }
+            candidate = candidate.plusWeeks(1);
+        }
+
+        return created;
+    }
+
+    private void validateSchedule(Activite activite) {
+        if (activite.getJour() == null || activite.getHoraireDebut() == null || activite.getDuree() == null) {
+            throw new IllegalArgumentException("Le jour, l'heure de début et la durée de l'activité sont obligatoires");
+        }
+        if (activite.getDuree() <= 0) {
+            throw new IllegalArgumentException("La durée de l'activité doit être supérieure à zéro");
         }
     }
 
@@ -100,7 +177,7 @@ public class SeanceServices {
         }
 
         Records holidays = response(joursFeriesApi, joursFeriesDataset,
-                "date >= date'" + start + "' and date <= date'" + end + "'");
+                "statut=\"férié\" and date >= date'" + start + "' and date <= date'" + end + "'");
         holidays.getResults().stream().map(record -> date(record, "date")).filter(java.util.Objects::nonNull)
                 .forEach(dates::add);
         return dates;
@@ -122,6 +199,57 @@ public class SeanceServices {
         }
         String isoDate = value.toString();
         return LocalDate.parse(isoDate.substring(0, Math.min(10, isoDate.length())));
+    }
+
+    public Seance updateSeance(Long activiteId, Long seanceId, ESeance etatSeance,
+                               String commentaire, boolean commentairePresent,
+                               LocalDate date, LocalTime heureDebut, boolean horairePresent) {
+        if (etatSeance == null && !commentairePresent && !horairePresent) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Aucune modification demandée");
+        }
+        if (etatSeance != null) {
+            ensureUpdated(seanceRepository.updateEtat(seanceId, activiteId, etatSeance));
+        }
+        if (commentairePresent) {
+            String normalizedComment = commentaire == null || commentaire.isBlank() ? null : commentaire.trim();
+            ensureUpdated(seanceRepository.updateCommentaire(seanceId, activiteId, normalizedComment));
+        }
+        if (horairePresent) {
+            updateHoraire(activiteId, seanceId, date, heureDebut);
+        }
+        return getSeance(activiteId, seanceId);
+    }
+
+    private void updateHoraire(Long activiteId, Long seanceId, LocalDate date, LocalTime heureDebut) {
+        if (date == null || heureDebut == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La date et l'heure sont obligatoires");
+        }
+        Seance seance = getSeance(activiteId, seanceId);
+        if (seance.getDebut() == null || seance.getFin() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Les horaires actuels de la séance sont incomplets");
+        }
+        Duration duration = Duration.between(seance.getDebut(), seance.getFin());
+        if (duration.isNegative() || duration.isZero()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La durée actuelle de la séance est invalide");
+        }
+        LocalDateTime nouveauDebut = LocalDateTime.of(date, heureDebut);
+        ensureUpdated(seanceRepository.updateHoraire(
+                seanceId, activiteId, nouveauDebut, nouveauDebut.plus(duration)));
+    }
+
+    public void deleteSeance(Long activiteId, Long seanceId) {
+        seanceRepository.delete(getSeance(activiteId, seanceId));
+    }
+
+    private Seance getSeance(Long activiteId, Long seanceId) {
+        return seanceRepository.findByIdAndActivite_Id(seanceId, activiteId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Séance introuvable"));
+    }
+
+    private void ensureUpdated(int updatedRows) {
+        if (updatedRows == 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Séance introuvable");
+        }
     }
 
     public void modifyDay(Activite activite){

--- a/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/SeanceServices.java
@@ -3,6 +3,7 @@ package com.wild.corp.adhesion.services;
 import com.wild.corp.adhesion.models.*;
 import com.wild.corp.adhesion.models.resources.SeanceCalendrierResponse;
 import com.wild.corp.adhesion.repository.SeanceRepository;
+import com.wild.corp.adhesion.repository.SalleRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +36,9 @@ public class SeanceServices {
 
     @Autowired
     SeanceRepository seanceRepository;
+
+    @Autowired
+    SalleRepository salleRepository;
 
     private final DatasetApi vacancesApi;
     private final DatasetApi joursFeriesApi;
@@ -81,6 +85,7 @@ public class SeanceServices {
     public Seance addFirstSeance(Activite activite, LocalDate date) {
         Seance nouvelleSeance = new Seance();
         nouvelleSeance.setActivite(activite);
+        nouvelleSeance.setSalle(activite.getSalle());
         nouvelleSeance.setDebut(LocalDateTime.of(date, activite.getHoraireDebut()));
         nouvelleSeance.setFin(nouvelleSeance.getDebut().plusMinutes(activite.getDuree()));
         nouvelleSeance.setEtatSeance(ESeance.PROGRAMMEE);
@@ -213,8 +218,9 @@ public class SeanceServices {
 
     public Seance updateSeance(Long activiteId, Long seanceId, ESeance etatSeance,
                                String commentaire, boolean commentairePresent,
-                               LocalDate date, LocalTime heureDebut, boolean horairePresent) {
-        if (etatSeance == null && !commentairePresent && !horairePresent) {
+                               LocalDate date, LocalTime heureDebut, boolean horairePresent,
+                               Long salleId, boolean sallePresente) {
+        if (etatSeance == null && !commentairePresent && !horairePresent && !sallePresente) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Aucune modification demandée");
         }
         if (etatSeance != null) {
@@ -227,7 +233,18 @@ public class SeanceServices {
         if (horairePresent) {
             updateHoraire(activiteId, seanceId, date, heureDebut);
         }
+        if (sallePresente) {
+            getSeance(activiteId, seanceId).setSalle(trouverSalle(salleId));
+        }
         return getSeance(activiteId, seanceId);
+    }
+
+    private Salle trouverSalle(Long salleId) {
+        if (salleId == null) {
+            return null;
+        }
+        return salleRepository.findById(salleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "La salle sélectionnée n'existe plus"));
     }
 
     private void updateHoraire(Long activiteId, Long seanceId, LocalDate date, LocalTime heureDebut) {

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -35,3 +35,4 @@ image-storage-dir: C:\Users\PC\Documents\ProjetsDev\Adhesion
 adhesion:
   calendrier:
     zone: ${ZONE_SCOLAIRE:C}
+    jours-feries-dataset: ${JOURS_FERIES_DATASET:jours-ouvres-week-end-feries-france-2010-a-2030}

--- a/app/src/test/java/com/wild/corp/adhesion/services/ActiviteServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/ActiviteServicesTest.java
@@ -1,0 +1,66 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.models.Activite;
+import com.wild.corp.adhesion.models.Seance;
+import com.wild.corp.adhesion.repository.ActiviteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActiviteServicesTest {
+
+    @Mock
+    private ActiviteRepository activiteRepository;
+
+    @Mock
+    private SeanceServices seanceServices;
+
+    @Mock
+    private AdherentServices adherentServices;
+
+    @InjectMocks
+    private ActiviteServices activiteServices;
+
+    @Test
+    void updatesAnActivityWithoutReplacingOrDeletingItsSessions() {
+        Activite activiteInDB = new Activite();
+        activiteInDB.setId(12L);
+        activiteInDB.setNom("Ancien nom");
+        activiteInDB.setJour(DayOfWeek.TUESDAY);
+
+        Seance seance = new Seance();
+        seance.setId(31L);
+        seance.setActivite(activiteInDB);
+        seance.setDebut(LocalDateTime.of(2026, 9, 1, 8, 15));
+        seance.setFin(LocalDateTime.of(2026, 9, 1, 9, 0));
+        activiteInDB.getSeances().add(seance);
+
+        Activite modification = new Activite();
+        modification.setId(12L);
+        modification.setNom("Nouveau nom");
+        modification.setJour(DayOfWeek.WEDNESDAY);
+
+        when(activiteRepository.findById(12L)).thenReturn(Optional.of(activiteInDB));
+        when(activiteRepository.save(activiteInDB)).thenReturn(activiteInDB);
+
+        Activite resultat = activiteServices.save(modification);
+
+        assertThat(resultat.getNom()).isEqualTo("Nouveau nom");
+        assertThat(resultat.getJour()).isEqualTo(DayOfWeek.WEDNESDAY);
+        assertThat(resultat.getSeances()).containsExactly(seance);
+        verify(seanceServices, never()).modifyDay(activiteInDB);
+        verify(activiteRepository).save(activiteInDB);
+    }
+}

--- a/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaConfigurationServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaConfigurationServicesTest.java
@@ -1,0 +1,94 @@
+package com.wild.corp.adhesion.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wild.corp.adhesion.models.GoogleAgenda;
+import com.wild.corp.adhesion.models.resources.AgendaGoogleConfiguration;
+import com.wild.corp.adhesion.repository.GoogleAgendaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GoogleAgendaConfigurationServicesTest {
+
+    private GoogleAgendaRepository googleAgendaRepository;
+    private ParamTextServices paramTextServices;
+    private GoogleAgendaConfigurationServices service;
+
+    @BeforeEach
+    void setUp() {
+        googleAgendaRepository = mock(GoogleAgendaRepository.class);
+        paramTextServices = mock(ParamTextServices.class);
+        service = new GoogleAgendaConfigurationServices(
+                googleAgendaRepository,
+                paramTextServices,
+                new GoogleAgendaServices(HttpClient.newHttpClient()),
+                new ObjectMapper());
+    }
+
+    @Test
+    void createsANamedAgendaWithNormalizedSourceAndColor() {
+        when(googleAgendaRepository.save(any())).thenAnswer(invocation -> {
+            GoogleAgenda agenda = invocation.getArgument(0);
+            agenda.setId(12L);
+            return agenda;
+        });
+
+        AgendaGoogleConfiguration agenda = service.create(new AgendaGoogleConfiguration(
+                null,
+                "Événements ALOD",
+                "https://calendar.google.com/calendar/embed?src=demo%40group.calendar.google.com",
+                "#a1b2c3"));
+
+        assertThat(agenda).isEqualTo(new AgendaGoogleConfiguration(
+                12L, "Événements ALOD", "demo@group.calendar.google.com", "#A1B2C3"));
+    }
+
+    @Test
+    void updatesTheNameSourceAndColorOfAnExistingAgenda() {
+        GoogleAgenda agenda = GoogleAgenda.builder()
+                .id(8L)
+                .nom("Ancien nom")
+                .source("ancien@group.calendar.google.com")
+                .couleur("#4285F4")
+                .build();
+        when(googleAgendaRepository.findById(8L)).thenReturn(Optional.of(agenda));
+        when(googleAgendaRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AgendaGoogleConfiguration resultat = service.update(8L, new AgendaGoogleConfiguration(
+                8L, "Nouvel agenda", "nouveau@group.calendar.google.com", "#DB4437"));
+
+        assertThat(resultat.nom()).isEqualTo("Nouvel agenda");
+        assertThat(resultat.source()).isEqualTo("nouveau@group.calendar.google.com");
+        assertThat(resultat.couleur()).isEqualTo("#DB4437");
+    }
+
+    @Test
+    void migratesTheLegacyTextConfigurationIntoTheDedicatedTable() {
+        when(paramTextServices.getParamValueOrDefault("Google_Agendas", ""))
+                .thenReturn("premier@group.calendar.google.com\nsecond@group.calendar.google.com");
+        when(googleAgendaRepository.findAllByOrderByNomAsc()).thenReturn(List.of());
+
+        service.getAll();
+
+        verify(googleAgendaRepository).saveAll(any());
+    }
+
+    @Test
+    void rejectsMissingNamesAndInvalidColors() {
+        assertThatThrownBy(() -> service.create(new AgendaGoogleConfiguration(
+                null, "", "demo@group.calendar.google.com", "blue")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("nom");
+    }
+}

--- a/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaServicesTest.java
@@ -21,13 +21,29 @@ class GoogleAgendaServicesTest {
                 VERSION:2.0
                 PRODID:-//Adhesion Test//FR
                 X-WR-CALNAME:Agenda public
+                BEGIN:VTIMEZONE
+                TZID:Europe/Paris
+                BEGIN:DAYLIGHT
+                TZOFFSETFROM:+0100
+                TZOFFSETTO:+0200
+                DTSTART:19700329T020000
+                RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+                END:DAYLIGHT
+                BEGIN:STANDARD
+                TZOFFSETFROM:+0200
+                TZOFFSETTO:+0100
+                DTSTART:19701025T030000
+                RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+                END:STANDARD
+                END:VTIMEZONE
                 BEGIN:VEVENT
                 UID:cours-google
-                DTSTART:20260901T190000
-                DTEND:20260901T200000
+                DTSTART;TZID=Europe/Paris:20260901T190000
+                DTEND;TZID=Europe/Paris:20260901T200000
                 RRULE:FREQ=WEEKLY;COUNT=3
                 SUMMARY:Cours externe
                 LOCATION:Salle Google
+                DESCRIPTION:Commentaire public de l'événement
                 END:VEVENT
                 BEGIN:VEVENT
                 UID:journee-google
@@ -46,10 +62,14 @@ class GoogleAgendaServicesTest {
         assertThat(evenements).filteredOn(evenement -> evenement.titre().equals("Cours externe"))
                 .extracting(evenement -> evenement.debut().toLocalDate())
                 .containsExactly(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 8), LocalDate.of(2026, 9, 15));
+        assertThat(evenements).filteredOn(evenement -> evenement.titre().equals("Cours externe"))
+                .extracting(evenement -> evenement.commentaire())
+                .containsOnly("Commentaire public de l'événement");
         assertThat(evenements).filteredOn(evenement -> evenement.journeeEntiere())
                 .singleElement().satisfies(evenement -> {
                     assertThat(evenement.debut()).isEqualTo(LocalDateTime.of(2026, 9, 5, 0, 0));
                     assertThat(evenement.agenda()).isEqualTo("Agenda public");
+                    assertThat(evenement.agendaSource()).isEqualTo("demo@group.calendar.google.com");
                 });
     }
 

--- a/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/GoogleAgendaServicesTest.java
@@ -1,0 +1,70 @@
+package com.wild.corp.adhesion.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoogleAgendaServicesTest {
+
+    private final GoogleAgendaServices service = new GoogleAgendaServices(HttpClient.newHttpClient());
+
+    @Test
+    void parsesTimedRecurringAndAllDayEvents() throws Exception {
+        String ics = """
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:-//Adhesion Test//FR
+                X-WR-CALNAME:Agenda public
+                BEGIN:VEVENT
+                UID:cours-google
+                DTSTART:20260901T190000
+                DTEND:20260901T200000
+                RRULE:FREQ=WEEKLY;COUNT=3
+                SUMMARY:Cours externe
+                LOCATION:Salle Google
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:journee-google
+                DTSTART;VALUE=DATE:20260905
+                DTEND;VALUE=DATE:20260906
+                SUMMARY:Journée associative
+                TRANSP:TRANSPARENT
+                END:VEVENT
+                END:VCALENDAR
+                """;
+
+        var evenements = service.lireCalendrier(ics.getBytes(StandardCharsets.UTF_8),
+                "demo@group.calendar.google.com", LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30));
+
+        assertThat(evenements).hasSize(4);
+        assertThat(evenements).filteredOn(evenement -> evenement.titre().equals("Cours externe"))
+                .extracting(evenement -> evenement.debut().toLocalDate())
+                .containsExactly(LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 8), LocalDate.of(2026, 9, 15));
+        assertThat(evenements).filteredOn(evenement -> evenement.journeeEntiere())
+                .singleElement().satisfies(evenement -> {
+                    assertThat(evenement.debut()).isEqualTo(LocalDateTime.of(2026, 9, 5, 0, 0));
+                    assertThat(evenement.agenda()).isEqualTo("Agenda public");
+                });
+    }
+
+    @Test
+    void acceptsPublicGoogleShareEmbedAndIcalUrls() {
+        String id = "demo@group.calendar.google.com";
+        String cid = Base64.getUrlEncoder().withoutPadding().encodeToString(id.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(service.extraireIdentifiant(id)).isEqualTo(id);
+        assertThat(service.extraireIdentifiant(
+                "https://calendar.google.com/calendar/embed?src=demo%40group.calendar.google.com")).isEqualTo(id);
+        assertThat(service.extraireIdentifiant(
+                "https://calendar.google.com/calendar/u/0?cid=" + cid)).isEqualTo(id);
+        assertThat(service.extraireIdentifiant(
+                "https://calendar.google.com/calendar/ical/demo%40group.calendar.google.com/public/basic.ics"))
+                .isEqualTo(id);
+    }
+}

--- a/app/src/test/java/com/wild/corp/adhesion/services/SalleConfigurationServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/SalleConfigurationServicesTest.java
@@ -1,0 +1,48 @@
+package com.wild.corp.adhesion.services;
+
+import com.wild.corp.adhesion.models.Salle;
+import com.wild.corp.adhesion.models.resources.SalleConfiguration;
+import com.wild.corp.adhesion.repository.SalleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SalleConfigurationServicesTest {
+
+    private SalleRepository salleRepository;
+    private SalleConfigurationServices service;
+
+    @BeforeEach
+    void setUp() {
+        salleRepository = mock(SalleRepository.class);
+        service = new SalleConfigurationServices(salleRepository);
+    }
+
+    @Test
+    void createsASalleWithNormalizedValues() {
+        when(salleRepository.save(any())).thenAnswer(invocation -> {
+            Salle salle = invocation.getArgument(0);
+            salle.setId(12L);
+            return salle;
+        });
+
+        SalleConfiguration salle = service.create(new SalleConfiguration(
+                null, "  Salle polyvalente ", " 12 rue des Fleurs ", "#a1b2c3"));
+
+        assertThat(salle).isEqualTo(new SalleConfiguration(
+                12L, "Salle polyvalente", "12 rue des Fleurs", "#A1B2C3"));
+    }
+
+    @Test
+    void rejectsAMissingAddress() {
+        assertThatThrownBy(() -> service.create(new SalleConfiguration(null, "Salle", "", "#4285F4")))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("adresse");
+    }
+}

--- a/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
@@ -2,6 +2,7 @@ package com.wild.corp.adhesion.services;
 
 import com.wild.corp.adhesion.models.Activite;
 import com.wild.corp.adhesion.models.ESeance;
+import com.wild.corp.adhesion.models.Salle;
 import com.wild.corp.adhesion.models.Seance;
 import com.wild.corp.adhesion.repository.SeanceRepository;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,8 @@ class SeanceServicesTest {
         activite.setId(5L);
         activite.setNom("Pilates");
         activite.setHoraire("Mardi de 19h30 à 20h30");
-        activite.setSalle("Salle des sports");
+        activite.setSalle(Salle.builder().id(4L).nom("Salle des sports").adresse("1 rue des Sports")
+                .couleur("#4285F4").build());
 
         Seance seance = new Seance();
         seance.setId(42L);
@@ -56,6 +58,8 @@ class SeanceServicesTest {
         assertThat(calendrier).singleElement().satisfies(evenement -> {
             assertThat(evenement.activiteNom()).isEqualTo("Pilates");
             assertThat(evenement.salle()).isEqualTo("Salle des sports");
+            assertThat(evenement.adresseSalle()).isEqualTo("1 rue des Sports");
+            assertThat(evenement.couleurSalle()).isEqualTo("#4285F4");
             assertThat(evenement.debut()).isEqualTo(LocalDateTime.of(2026, 9, 1, 19, 30));
         });
     }

--- a/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
@@ -41,6 +41,7 @@ class SeanceServicesTest {
         Seance seance = new Seance();
         seance.setId(42L);
         seance.setActivite(activite);
+        seance.setSalle(activite.getSalle());
         seance.setDebut(LocalDateTime.of(2026, 9, 1, 19, 30));
         seance.setFin(LocalDateTime.of(2026, 9, 1, 20, 30));
         seance.setEtatSeance(ESeance.PROGRAMMEE);
@@ -99,6 +100,18 @@ class SeanceServicesTest {
     }
 
     @Test
+    void initializesEachSessionWithTheActivityRoom() {
+        SeanceServices service = serviceWithRepository(mock(SeanceRepository.class));
+        Activite activite = activity();
+        Salle salle = Salle.builder().id(8L).nom("Gymnase").adresse("1 rue du Gymnase").couleur("#123456").build();
+        activite.setSalle(salle);
+
+        Seance seance = service.addFirstSeance(activite, LocalDate.of(2026, 9, 7));
+
+        assertThat(seance.getSalle()).isSameAs(salle);
+    }
+
+    @Test
     void addsTheRequestedNumberOfSessionsAndSkipsExistingDates() {
         DatasetApi vacancesApi = mock(DatasetApi.class);
         DatasetApi joursFeriesApi = mock(DatasetApi.class);
@@ -148,12 +161,12 @@ class SeanceServicesTest {
         SeanceServices service = serviceWithRepository(repository);
 
         Seance updated = service.updateSeance(
-                3L, 7L, ESeance.REALISEE, null, false, null, null, false);
+                3L, 7L, ESeance.REALISEE, null, false, null, null, false, null, false);
 
         assertThat(updated.getEtatSeance()).isEqualTo(ESeance.REALISEE);
         assertThat(updated.getCommentaire()).isEqualTo("Commentaire conservé");
         service.updateSeance(
-                3L, 7L, null, "  Présents au complet  ", true, null, null, false);
+                3L, 7L, null, "  Présents au complet  ", true, null, null, false, null, false);
         assertThat(updated.getCommentaire()).isEqualTo("Présents au complet");
         verify(repository).updateEtat(7L, 3L, ESeance.REALISEE);
         verify(repository).updateCommentaire(7L, 3L, "Présents au complet");
@@ -178,7 +191,7 @@ class SeanceServicesTest {
 
         Seance updated = service.updateSeance(
                 3L, 11L, null, null, false,
-                LocalDate.of(2026, 9, 8), LocalTime.of(10, 30), true);
+                LocalDate.of(2026, 9, 8), LocalTime.of(10, 30), true, null, false);
 
         assertThat(updated.getDebut()).isEqualTo(nouveauDebut);
         assertThat(updated.getFin()).isEqualTo(nouvelleFin);

--- a/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
+++ b/app/src/test/java/com/wild/corp/adhesion/services/SeanceServicesTest.java
@@ -1,6 +1,9 @@
 package com.wild.corp.adhesion.services;
 
 import com.wild.corp.adhesion.models.Activite;
+import com.wild.corp.adhesion.models.ESeance;
+import com.wild.corp.adhesion.models.Seance;
+import com.wild.corp.adhesion.repository.SeanceRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 import org.wild.corp.adhesion.client.vacances.api.DatasetApi;
@@ -12,14 +15,50 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SeanceServicesTest {
+
+    @Test
+    void exposesPublicCalendarDataWithoutSessionComments() {
+        SeanceRepository repository = mock(SeanceRepository.class);
+        Activite activite = new Activite();
+        activite.setId(5L);
+        activite.setNom("Pilates");
+        activite.setHoraire("Mardi de 19h30 à 20h30");
+        activite.setSalle("Salle des sports");
+
+        Seance seance = new Seance();
+        seance.setId(42L);
+        seance.setActivite(activite);
+        seance.setDebut(LocalDateTime.of(2026, 9, 1, 19, 30));
+        seance.setFin(LocalDateTime.of(2026, 9, 1, 20, 30));
+        seance.setEtatSeance(ESeance.PROGRAMMEE);
+        seance.setCommentaire("Information interne");
+
+        when(repository.findAllByDebutGreaterThanEqualAndDebutLessThanOrderByDebut(
+                LocalDateTime.of(2026, 8, 31, 0, 0),
+                LocalDateTime.of(2026, 10, 12, 0, 0)))
+                .thenReturn(List.of(seance));
+        SeanceServices service = serviceWithRepository(repository);
+
+        var calendrier = service.getCalendrier(
+                LocalDate.of(2026, 8, 31), LocalDate.of(2026, 10, 11));
+
+        assertThat(calendrier).singleElement().satisfies(evenement -> {
+            assertThat(evenement.activiteNom()).isEqualTo("Pilates");
+            assertThat(evenement.salle()).isEqualTo("Salle des sports");
+            assertThat(evenement.debut()).isEqualTo(LocalDateTime.of(2026, 9, 1, 19, 30));
+        });
+    }
 
     @Test
     void createsWeeklySessionsAtActivityStartAndSkipsVacationsAndPublicHolidays() {
@@ -49,6 +88,117 @@ class SeanceServicesTest {
                 LocalDateTime.of(2026, 10, 5, 18, 30));
         assertThat(activite.getSeances().getFirst().getFin())
                 .isEqualTo(LocalDateTime.of(2026, 9, 28, 20, 0));
+        verify(joursFeriesApi).getRecords(eq("feries"), nullable(String.class),
+                argThat(where -> where.contains("statut=\"férié\"")), nullable(String.class), nullable(String.class),
+                eq(100), eq(0), nullable(String.class), nullable(String.class), eq("fr"),
+                eq("Europe/Paris"), eq(false), eq(false));
+    }
+
+    @Test
+    void addsTheRequestedNumberOfSessionsAndSkipsExistingDates() {
+        DatasetApi vacancesApi = mock(DatasetApi.class);
+        DatasetApi joursFeriesApi = mock(DatasetApi.class);
+        Records vacations = new Records().results(List.of(new Record()
+                .putAdditionalProperty("start_date", "2026-09-12T00:00:00+02:00")
+                .putAdditionalProperty("end_date", "2026-09-15T00:00:00+02:00")));
+        Records holidays = new Records().results(List.of(new Record()
+                .putAdditionalProperty("date", "2026-09-21")));
+
+        when(vacancesApi.getRecords(eq("vacances"), nullable(String.class), nullable(String.class),
+                nullable(String.class), nullable(String.class), eq(100), eq(0), nullable(String.class),
+                nullable(String.class), eq("fr"), eq("Europe/Paris"), eq(false), eq(false)))
+                .thenReturn(ResponseEntity.ok(vacations));
+        when(joursFeriesApi.getRecords(eq("feries"), nullable(String.class), nullable(String.class),
+                nullable(String.class), nullable(String.class), eq(100), eq(0), nullable(String.class),
+                nullable(String.class), eq("fr"), eq("Europe/Paris"), eq(false), eq(false)))
+                .thenReturn(ResponseEntity.ok(holidays));
+
+        SeanceServices service = new SeanceServices(vacancesApi, joursFeriesApi, "C", "vacances", "feries");
+        Activite activite = activity();
+        activite.getSeances().add(service.addFirstSeance(activite, LocalDate.of(2026, 9, 28)));
+
+        List<Seance> created = service.addSeances(activite, 2, "C", LocalDate.of(2026, 9, 8));
+
+        assertThat(created).extracting("debut").containsExactly(
+                LocalDateTime.of(2026, 10, 5, 18, 30),
+                LocalDateTime.of(2026, 10, 12, 18, 30));
+        assertThat(activite.getSeances()).hasSize(3);
+    }
+
+    @Test
+    void updatesTheStateAndCommentForTheRequestedActivitySession() {
+        SeanceRepository repository = mock(SeanceRepository.class);
+        Seance seance = new Seance();
+        seance.setId(7L);
+        seance.setEtatSeance(ESeance.PROGRAMMEE);
+        seance.setCommentaire("Commentaire conservé");
+        when(repository.updateEtat(7L, 3L, ESeance.REALISEE)).thenAnswer(invocation -> {
+            seance.setEtatSeance(ESeance.REALISEE);
+            return 1;
+        });
+        when(repository.updateCommentaire(7L, 3L, "Présents au complet")).thenAnswer(invocation -> {
+            seance.setCommentaire("Présents au complet");
+            return 1;
+        });
+        when(repository.findByIdAndActivite_Id(7L, 3L)).thenReturn(Optional.of(seance));
+        SeanceServices service = serviceWithRepository(repository);
+
+        Seance updated = service.updateSeance(
+                3L, 7L, ESeance.REALISEE, null, false, null, null, false);
+
+        assertThat(updated.getEtatSeance()).isEqualTo(ESeance.REALISEE);
+        assertThat(updated.getCommentaire()).isEqualTo("Commentaire conservé");
+        service.updateSeance(
+                3L, 7L, null, "  Présents au complet  ", true, null, null, false);
+        assertThat(updated.getCommentaire()).isEqualTo("Présents au complet");
+        verify(repository).updateEtat(7L, 3L, ESeance.REALISEE);
+        verify(repository).updateCommentaire(7L, 3L, "Présents au complet");
+    }
+
+    @Test
+    void updatesTheDateAndStartTimeWhileKeepingTheSessionDuration() {
+        SeanceRepository repository = mock(SeanceRepository.class);
+        Seance seance = new Seance();
+        seance.setId(11L);
+        seance.setDebut(LocalDateTime.of(2026, 9, 1, 8, 15));
+        seance.setFin(LocalDateTime.of(2026, 9, 1, 9, 0));
+        LocalDateTime nouveauDebut = LocalDateTime.of(2026, 9, 8, 10, 30);
+        LocalDateTime nouvelleFin = LocalDateTime.of(2026, 9, 8, 11, 15);
+        when(repository.findByIdAndActivite_Id(11L, 3L)).thenReturn(Optional.of(seance));
+        when(repository.updateHoraire(11L, 3L, nouveauDebut, nouvelleFin)).thenAnswer(invocation -> {
+            seance.setDebut(nouveauDebut);
+            seance.setFin(nouvelleFin);
+            return 1;
+        });
+        SeanceServices service = serviceWithRepository(repository);
+
+        Seance updated = service.updateSeance(
+                3L, 11L, null, null, false,
+                LocalDate.of(2026, 9, 8), LocalTime.of(10, 30), true);
+
+        assertThat(updated.getDebut()).isEqualTo(nouveauDebut);
+        assertThat(updated.getFin()).isEqualTo(nouvelleFin);
+        verify(repository).updateHoraire(11L, 3L, nouveauDebut, nouvelleFin);
+    }
+
+    @Test
+    void deletesOnlyTheRequestedActivitySession() {
+        SeanceRepository repository = mock(SeanceRepository.class);
+        Seance seance = new Seance();
+        seance.setId(9L);
+        when(repository.findByIdAndActivite_Id(9L, 4L)).thenReturn(Optional.of(seance));
+        SeanceServices service = serviceWithRepository(repository);
+
+        service.deleteSeance(4L, 9L);
+
+        verify(repository).delete(seance);
+    }
+
+    private SeanceServices serviceWithRepository(SeanceRepository repository) {
+        SeanceServices service = new SeanceServices(
+                mock(DatasetApi.class), mock(DatasetApi.class), "C", "vacances", "feries");
+        service.seanceRepository = repository;
+        return service;
     }
 
     private Activite activity() {

--- a/client/angular.json
+++ b/client/angular.json
@@ -53,7 +53,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumError": "6kb"
                 }
               ],
               "fileReplacements": [
@@ -74,7 +74,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumError": "6kb"
                 }
               ],
               "fileReplacements": [

--- a/client/src/app/_helpers/auth.interceptor.ts
+++ b/client/src/app/_helpers/auth.interceptor.ts
@@ -1,16 +1,17 @@
-import { HTTP_INTERCEPTORS, HttpEvent } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpErrorResponse, HttpEvent } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Router } from '@angular/router';
 
 import { TokenStorageService } from '../_services/token-storage.service';
-import { Observable } from 'rxjs';
+import { catchError, Observable, throwError } from 'rxjs';
 
 // const TOKEN_HEADER_KEY = 'Authorization';       // for Spring Boot back-end
 const TOKEN_HEADER_KEY = 'Authorization';   // for Node.js Express back-end
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(private token: TokenStorageService) { }
+  constructor(private token: TokenStorageService, private router: Router) { }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     let authReq = req;
@@ -22,7 +23,19 @@ export class AuthInterceptor implements HttpInterceptor {
       // for Node.js Express back-end
       authReq = req.clone({ headers: req.headers.set(TOKEN_HEADER_KEY,  'Bearer ' + token) });
     }
-    return next.handle(authReq);
+    return next.handle(authReq).pipe(
+      catchError(error => {
+        if (error instanceof HttpErrorResponse
+          && error.status === 401
+          && this.token.getToken() != null) {
+          this.token.signOut();
+          void this.router.navigate(['/login'], {
+            queryParams: { sessionExpiree: '1' }
+          });
+        }
+        return throwError(() => error);
+      })
+    );
   }
 }
 

--- a/client/src/app/_services/activite.service.ts
+++ b/client/src/app/_services/activite.service.ts
@@ -21,8 +21,9 @@ export class ActiviteService {
     return this.http.get<Seance[]>(API_URL + activiteId + '/seances', { responseType: 'json' });
   }
 
-  getCalendrier(dateDebut: string, dateFin: string): Observable<SeanceCalendrier[]> {
-    const params = new HttpParams().set('dateDebut', dateDebut).set('dateFin', dateFin);
+  getCalendrier(dateDebut: string, dateFin: string, tribuUuid?: string): Observable<SeanceCalendrier[]> {
+    let params = new HttpParams().set('dateDebut', dateDebut).set('dateFin', dateFin);
+    if (tribuUuid) params = params.set('tribuUuid', tribuUuid);
     return this.http.get<SeanceCalendrier[]>(API_URL + 'calendrier', { params, responseType: 'json' });
   }
 

--- a/client/src/app/_services/activite.service.ts
+++ b/client/src/app/_services/activite.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { Activite, Adherent,ActiviteNm1, ActiviteDropDown, HoraireDropDown } from '../models';
-import { Seance } from '../models/seance';
+import { CalendrierGoogle, Seance, SeanceCalendrier } from '../models/seance';
 
 const API_URL = environment.server + '/activite/';
 
@@ -15,6 +15,53 @@ export class ActiviteService {
 
   getSeancesDuJour(): Observable<Seance[]> {
     return this.http.get<Seance[]>(API_URL + 'seancesDuJour', { responseType: 'json' });
+  }
+
+  getSeances(activiteId: number): Observable<Seance[]> {
+    return this.http.get<Seance[]>(API_URL + activiteId + '/seances', { responseType: 'json' });
+  }
+
+  getCalendrier(dateDebut: string, dateFin: string): Observable<SeanceCalendrier[]> {
+    const params = new HttpParams().set('dateDebut', dateDebut).set('dateFin', dateFin);
+    return this.http.get<SeanceCalendrier[]>(API_URL + 'calendrier', { params, responseType: 'json' });
+  }
+
+  getCalendrierGoogle(dateDebut: string, dateFin: string, sources: string[]): Observable<CalendrierGoogle> {
+    let params = new HttpParams().set('dateDebut', dateDebut).set('dateFin', dateFin);
+    sources.forEach(source => params = params.append('source', source));
+    return this.http.get<CalendrierGoogle>(API_URL + 'calendrier/google', { params, responseType: 'json' });
+  }
+
+  ajouterSeances(activiteId: number, nombreSeances: number, dateDebut: string): Observable<Seance[]> {
+    return this.http.post<Seance[]>(API_URL + activiteId + '/seances', {
+      nombreSeances,
+      dateDebut
+    }, { responseType: 'json' });
+  }
+
+  modifierEtatSeance(activiteId: number, seance: Seance): Observable<Seance> {
+    return this.http.patch<Seance>(API_URL + activiteId + '/seances/' + seance.id, {
+      etatSeance: seance.etatSeance
+    }, { responseType: 'json' });
+  }
+
+  modifierCommentaireSeance(activiteId: number, seance: Seance): Observable<Seance> {
+    return this.http.patch<Seance>(API_URL + activiteId + '/seances/' + seance.id, {
+      commentaire: seance.commentaire,
+      commentairePresent: true
+    }, { responseType: 'json' });
+  }
+
+  modifierHoraireSeance(activiteId: number, seance: Seance): Observable<Seance> {
+    return this.http.patch<Seance>(API_URL + activiteId + '/seances/' + seance.id, {
+      date: seance.dateEdition,
+      heureDebut: seance.heureEdition,
+      horairePresent: true
+    }, { responseType: 'json' });
+  }
+
+  supprimerSeance(activiteId: number, seanceId: number): Observable<void> {
+    return this.http.delete<void>(API_URL + activiteId + '/seances/' + seanceId);
   }
 
   getAllNm1(): Observable<ActiviteNm1[]> {

--- a/client/src/app/_services/activite.service.ts
+++ b/client/src/app/_services/activite.service.ts
@@ -61,6 +61,13 @@ export class ActiviteService {
     }, { responseType: 'json' });
   }
 
+  modifierSalleSeance(activiteId: number, seance: Seance): Observable<Seance> {
+    return this.http.patch<Seance>(API_URL + activiteId + '/seances/' + seance.id, {
+      salleId: seance.salle?.id ?? null,
+      sallePresente: true
+    }, { responseType: 'json' });
+  }
+
   supprimerSeance(activiteId: number, seanceId: number): Observable<void> {
     return this.http.delete<void>(API_URL + activiteId + '/seances/' + seanceId);
   }

--- a/client/src/app/_services/param.service.ts
+++ b/client/src/app/_services/param.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient} from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { ParamBoolean, ParamNumber, ParamText } from '../models';
+import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText } from '../models';
 
 const API_URL = environment.server+'/param/';
 
@@ -18,6 +18,22 @@ export class ParamService {
 
   saveText(param: ParamText): Observable<ParamText> {
     return this.http.post<ParamText>(API_URL + 'saveText', param, { responseType: 'json' });
+  }
+
+  getAgendasGoogle(): Observable<AgendaGoogleConfiguration[]> {
+    return this.http.get<AgendaGoogleConfiguration[]>(API_URL + 'agendas', { responseType: 'json' });
+  }
+
+  createAgendaGoogle(agenda: AgendaGoogleConfiguration): Observable<AgendaGoogleConfiguration> {
+    return this.http.post<AgendaGoogleConfiguration>(API_URL + 'agendas', agenda, { responseType: 'json' });
+  }
+
+  updateAgendaGoogle(agenda: AgendaGoogleConfiguration): Observable<AgendaGoogleConfiguration> {
+    return this.http.put<AgendaGoogleConfiguration>(API_URL + 'agendas/' + agenda.id, agenda, { responseType: 'json' });
+  }
+
+  deleteAgendaGoogle(agendaId: number): Observable<void> {
+    return this.http.delete<void>(API_URL + 'agendas/' + agendaId);
   }
 
   getAllBoolean(): Observable<ParamBoolean[]> {
@@ -41,4 +57,3 @@ export class ParamService {
   }
 
 }
-

--- a/client/src/app/_services/param.service.ts
+++ b/client/src/app/_services/param.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient} from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
-import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText } from '../models';
+import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText, SalleConfiguration } from '../models';
 
 const API_URL = environment.server+'/param/';
 
@@ -34,6 +34,22 @@ export class ParamService {
 
   deleteAgendaGoogle(agendaId: number): Observable<void> {
     return this.http.delete<void>(API_URL + 'agendas/' + agendaId);
+  }
+
+  getSalles(): Observable<SalleConfiguration[]> {
+    return this.http.get<SalleConfiguration[]>(API_URL + 'salles', { responseType: 'json' });
+  }
+
+  createSalle(salle: SalleConfiguration): Observable<SalleConfiguration> {
+    return this.http.post<SalleConfiguration>(API_URL + 'salles', salle, { responseType: 'json' });
+  }
+
+  updateSalle(salle: SalleConfiguration): Observable<SalleConfiguration> {
+    return this.http.put<SalleConfiguration>(API_URL + 'salles/' + salle.id, salle, { responseType: 'json' });
+  }
+
+  deleteSalle(salleId: number): Observable<void> {
+    return this.http.delete<void>(API_URL + 'salles/' + salleId);
   }
 
   getAllBoolean(): Observable<ParamBoolean[]> {

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -51,6 +51,7 @@ import { FileService } from './_services/file.service';
 import { SimpleFilterPipe } from './_helpers/simpleFilter.pipe';
 import {OrderSimplePipe} from "./_helpers/sort-simple.pipe";
 import {OrderObjectByPipe} from "./_helpers/sortObject.pipe";
+import { CalendrierComponent } from './template/calendrier/calendrier.component';
 import localeFr from '@angular/common/locales/fr';
 registerLocaleData(localeFr);
 
@@ -75,6 +76,7 @@ registerLocaleData(localeFr);
     ModalActivite,
     UserComponent,
     SwitchComponent,
+    CalendrierComponent,
     OrderByPipe,
     FilterByPipe,
 

--- a/client/src/app/models/activite.ts
+++ b/client/src/app/models/activite.ts
@@ -10,6 +10,8 @@ export class Activite {
   groupeCompta!: string;
   tarif!: number;
   jour!: string;
+  horaireDebut!: string;
+  duree!: number;
   ageMin!: number;
   ageMax!: number;
   genre!: string;

--- a/client/src/app/models/activite.ts
+++ b/client/src/app/models/activite.ts
@@ -1,5 +1,6 @@
 import { Adherent } from "./adherent";
 import { Adhesion } from "./adhesion";
+import { SalleConfiguration } from './salle';
 
 export class Activite {
 
@@ -17,7 +18,7 @@ export class Activite {
   genre!: string;
   horaire!: string;
   lien!: string;
-  salle!: string;
+  salle?: SalleConfiguration;
   profs!: Adherent[];
   nbPlaces!: number;
   nbAdhesionsEnCours!: number;

--- a/client/src/app/models/agendaGoogle.ts
+++ b/client/src/app/models/agendaGoogle.ts
@@ -1,0 +1,6 @@
+export interface AgendaGoogleConfiguration {
+  id?: number;
+  nom: string;
+  source: string;
+  couleur: string;
+}

--- a/client/src/app/models/index.ts
+++ b/client/src/app/models/index.ts
@@ -23,3 +23,4 @@ export * from './adhesionExcel';
 export * from './paiement';
 export * from './notification';
 export * from './activiteDropDown';
+export * from './agendaGoogle';

--- a/client/src/app/models/index.ts
+++ b/client/src/app/models/index.ts
@@ -24,3 +24,4 @@ export * from './paiement';
 export * from './notification';
 export * from './activiteDropDown';
 export * from './agendaGoogle';
+export * from './salle';

--- a/client/src/app/models/salle.ts
+++ b/client/src/app/models/salle.ts
@@ -1,0 +1,6 @@
+export interface SalleConfiguration {
+  id?: number;
+  nom: string;
+  adresse: string;
+  couleur: string;
+}

--- a/client/src/app/models/seance.ts
+++ b/client/src/app/models/seance.ts
@@ -1,6 +1,6 @@
 export class Seance {
   id!: number;
-  etatSeance!: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE';
+  etatSeance!: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE' | 'MODIFIEE';
   causeAnnulation!: string;
   debut!: string;
   fin!: string;
@@ -15,9 +15,13 @@ export interface SeanceCalendrier {
   activiteNom: string;
   horaireActivite: string;
   salle: string;
+  adresseSalle: string | null;
+  couleurSalle: string | null;
+  commentaire: string | null;
+  lien: string | null;
   debut: string;
   fin: string;
-  etatSeance: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE';
+  etatSeance: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE' | 'MODIFIEE';
 }
 
 export interface EvenementGoogleAgenda {

--- a/client/src/app/models/seance.ts
+++ b/client/src/app/models/seance.ts
@@ -24,10 +24,12 @@ export interface EvenementGoogleAgenda {
   id: string;
   titre: string;
   lieu: string | null;
+  commentaire: string | null;
   debut: string;
   fin: string;
   journeeEntiere: boolean;
   agenda: string;
+  agendaSource: string;
 }
 
 export interface CalendrierGoogle {

--- a/client/src/app/models/seance.ts
+++ b/client/src/app/models/seance.ts
@@ -1,3 +1,5 @@
+import { SalleConfiguration } from './salle';
+
 export class Seance {
   id!: number;
   etatSeance!: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE' | 'MODIFIEE';
@@ -5,6 +7,7 @@ export class Seance {
   debut!: string;
   fin!: string;
   commentaire!: string;
+  salle?: SalleConfiguration;
   dateEdition!: string;
   heureEdition!: string;
 }

--- a/client/src/app/models/seance.ts
+++ b/client/src/app/models/seance.ts
@@ -1,17 +1,36 @@
-import { PresenceSeance } from "./presenceSeance";
-
-
 export class Seance {
-
   id!: number;
-
-  activiteId!: number;
-
-  numeroSeance!: number;
-
-  dateSeance!: string;
-
+  etatSeance!: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE';
+  causeAnnulation!: string;
+  debut!: string;
+  fin!: string;
   commentaire!: string;
+  dateEdition!: string;
+  heureEdition!: string;
+}
 
-  presenceSeance: PresenceSeance[]=[];
+export interface SeanceCalendrier {
+  id: number;
+  activiteId: number;
+  activiteNom: string;
+  horaireActivite: string;
+  salle: string;
+  debut: string;
+  fin: string;
+  etatSeance: 'PROGRAMMEE' | 'REALISEE' | 'ANNULEE';
+}
+
+export interface EvenementGoogleAgenda {
+  id: string;
+  titre: string;
+  lieu: string | null;
+  debut: string;
+  fin: string;
+  journeeEntiere: boolean;
+  agenda: string;
+}
+
+export interface CalendrierGoogle {
+  evenements: EvenementGoogleAgenda[];
+  erreurs: string[];
 }

--- a/client/src/app/page/board-admin/board-admin.component.css
+++ b/client/src/app/page/board-admin/board-admin.component.css
@@ -1,0 +1,185 @@
+.agenda-admin {
+  --agenda-encre: #263338;
+  --agenda-vert: #5cbbaf;
+  border: 0;
+  border-radius: 16px;
+  margin-bottom: 1.5rem;
+  padding: clamp(1rem, 2.5vw, 1.75rem);
+  box-shadow: 0 10px 28px rgba(38, 51, 56, 0.1);
+}
+
+.agenda-admin-entete,
+.agenda-admin-titre,
+.agenda-ajout,
+.agenda-ligne,
+.agenda-actions {
+  align-items: center;
+  display: flex;
+}
+
+.agenda-admin-entete,
+.agenda-actions {
+  justify-content: space-between;
+}
+
+.agenda-admin-entete {
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.agenda-admin-titre {
+  gap: 0.85rem;
+}
+
+.agenda-admin-titre h2 {
+  color: var(--agenda-encre);
+  margin: 0 0 0.15rem;
+}
+
+.agenda-admin-titre p {
+  color: #68767b;
+  margin: 0;
+}
+
+.agenda-admin-icone {
+  align-items: center;
+  background: #eaf7f4;
+  border-radius: 12px;
+  color: #387e75;
+  display: flex;
+  font-size: 1.35rem;
+  height: 48px;
+  justify-content: center;
+  width: 48px;
+}
+
+.agenda-compteur {
+  background: #f0f3f3;
+  border-radius: 999px;
+  color: #4f5f64;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.35rem 0.65rem;
+  white-space: nowrap;
+}
+
+.agenda-ajout {
+  background: #f7f9f9;
+  border: 1px solid #e0e7e8;
+  border-radius: 12px;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.agenda-source,
+.agenda-nom {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.agenda-nom {
+  flex-basis: 220px;
+}
+
+.agenda-source {
+  flex-basis: 360px;
+}
+
+.agenda-couleur {
+  flex: 0 0 84px;
+}
+
+.agenda-source label,
+.agenda-nom label,
+.agenda-couleur label {
+  color: var(--agenda-encre);
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.agenda-couleur input {
+  max-width: none;
+  min-height: 38px;
+  width: 100%;
+}
+
+.agenda-ajouter {
+  align-self: flex-end;
+  white-space: nowrap;
+}
+
+.agenda-liste {
+  border: 1px solid #e0e7e8;
+  border-radius: 12px;
+  margin-top: 1rem;
+  overflow: hidden;
+}
+
+.agenda-ligne {
+  gap: 0.75rem;
+  padding: 0.8rem 1rem;
+}
+
+.agenda-ligne + .agenda-ligne {
+  border-top: 1px solid #e0e7e8;
+}
+
+.agenda-apercu {
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px #cbd5d7;
+  flex: 0 0 24px;
+  height: 24px;
+}
+
+.agenda-supprimer {
+  align-self: flex-end;
+  flex: 0 0 42px;
+}
+
+.agenda-actions {
+  background: #f7f9f9;
+  border-top: 1px solid #e0e7e8;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+}
+
+.agenda-actions small {
+  color: #68767b;
+}
+
+.agenda-vide {
+  color: #68767b;
+  padding: 1.25rem 0 0.25rem;
+  text-align: center;
+}
+
+.agenda-retour {
+  margin: 1rem 0 0;
+}
+
+@media (max-width: 767px) {
+  .agenda-admin-entete,
+  .agenda-ajout,
+  .agenda-ligne,
+  .agenda-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .agenda-couleur {
+    flex-basis: auto;
+  }
+
+  .agenda-apercu {
+    position: absolute;
+  }
+
+  .agenda-ajouter,
+  .agenda-supprimer,
+  .agenda-actions .btn {
+    width: 100%;
+  }
+}

--- a/client/src/app/page/board-admin/board-admin.component.html
+++ b/client/src/app/page/board-admin/board-admin.component.html
@@ -1,5 +1,85 @@
 <div class="row">
 
+  <div class="col-12">
+    <section class="card card-container agenda-admin" aria-labelledby="titre-agenda-admin">
+      <div class="agenda-admin-entete">
+        <div class="agenda-admin-titre">
+          <span class="agenda-admin-icone" aria-hidden="true"><fa-icon [icon]="faCalendarDays"></fa-icon></span>
+          <div>
+            <h2 id="titre-agenda-admin">Agenda</h2>
+            <p>Ajoutez des Google Agendas publics et choisissez leur couleur dans le calendrier d'accueil.</p>
+          </div>
+        </div>
+        <span class="agenda-compteur">{{agendasGoogle.length}} / 10</span>
+      </div>
+
+      <div class="agenda-ajout">
+        <div class="agenda-nom">
+          <label for="nouvelAgendaNom">Nom de l'agenda</label>
+          <input id="nouvelAgendaNom" type="text" class="form-control" maxlength="100"
+                 [(ngModel)]="nouvelAgendaNom" placeholder="Ex. Événements de l'ALOD">
+        </div>
+        <div class="agenda-source">
+          <label for="nouvelAgendaSource">Identifiant ou URL publique Google Agenda</label>
+          <input id="nouvelAgendaSource" type="text" class="form-control"
+                 [(ngModel)]="nouvelAgendaSource"
+                 (keydown.enter)="ajouterAgenda()"
+                 placeholder="exemple@group.calendar.google.com ou https://calendar.google.com/…">
+        </div>
+        <div class="agenda-couleur">
+          <label for="nouvelAgendaCouleur">Couleur</label>
+          <input id="nouvelAgendaCouleur" type="color" class="form-control form-control-color"
+                 [(ngModel)]="nouvelAgendaCouleur" title="Choisir la couleur du nouvel agenda">
+        </div>
+        <button type="button" class="btn btn-primary agenda-ajouter"
+                [disabled]="agendaEnregistrement || agendasGoogle.length >= 10"
+                (click)="ajouterAgenda()">
+          <fa-icon [icon]="faPlus"></fa-icon>
+          Ajouter
+        </button>
+      </div>
+
+      <div *ngIf="agendasGoogle.length > 0" class="agenda-liste">
+        <div *ngFor="let agenda of agendasGoogle; let index = index" class="agenda-ligne">
+          <span class="agenda-apercu" [style.background-color]="agenda.couleur" aria-hidden="true"></span>
+          <div class="agenda-nom">
+            <label [for]="'agendaNom' + index">Nom</label>
+            <input [id]="'agendaNom' + index" type="text" class="form-control" maxlength="100"
+                   [(ngModel)]="agenda.nom">
+          </div>
+          <div class="agenda-source">
+            <label [for]="'agendaSource' + index">Identifiant public</label>
+            <input [id]="'agendaSource' + index" type="text" class="form-control"
+                   [(ngModel)]="agenda.source">
+          </div>
+          <div class="agenda-couleur">
+            <label [for]="'agendaCouleur' + index">Couleur</label>
+            <input [id]="'agendaCouleur' + index" type="color" class="form-control form-control-color"
+                   [(ngModel)]="agenda.couleur" [title]="'Couleur de l’agenda ' + (index + 1)">
+          </div>
+          <button type="button" class="btn btn-outline-danger agenda-supprimer"
+                  [disabled]="agendaEnregistrement"
+                  (click)="supprimerAgenda(index)" [attr.aria-label]="'Supprimer l’agenda ' + (index + 1)">
+            <fa-icon [icon]="faTrash"></fa-icon>
+          </button>
+        </div>
+        <div class="agenda-actions">
+          <small>Les modifications de nom, d'identifiant et de couleur sont appliquées après enregistrement.</small>
+          <button type="button" class="btn btn-outline-primary"
+                  [disabled]="agendaEnregistrement" (click)="enregistrerAgendas()">
+            {{agendaEnregistrement ? 'Enregistrement…' : 'Enregistrer les modifications'}}
+          </button>
+        </div>
+      </div>
+
+      <div *ngIf="agendasGoogle.length === 0 && !agendaErreur" class="agenda-vide">
+        Aucun agenda Google n'est configuré pour le moment.
+      </div>
+      <div *ngIf="agendaMessage" class="alert alert-success agenda-retour" role="status">{{agendaMessage}}</div>
+      <div *ngIf="agendaErreur" class="alert alert-danger agenda-retour" role="alert">{{agendaErreur}}</div>
+    </section>
+  </div>
+
   <!--div class="col-md-12">
     <div type='button' class="btn btn-block btn-primary" (click)="nouvelleAnnee()">Nouvelle Annee</div>
   </div-->

--- a/client/src/app/page/board-admin/board-admin.component.html
+++ b/client/src/app/page/board-admin/board-admin.component.html
@@ -80,6 +80,83 @@
     </section>
   </div>
 
+  <div class="col-12">
+    <section class="card card-container agenda-admin" aria-labelledby="titre-salles-admin">
+      <div class="agenda-admin-entete">
+        <div class="agenda-admin-titre">
+          <span class="agenda-admin-icone" aria-hidden="true"><fa-icon [icon]="faLocationDot"></fa-icon></span>
+          <div>
+            <h2 id="titre-salles-admin">Salles</h2>
+            <p>Enregistrez les salles utilisées par l’association, avec leur adresse et leur couleur.</p>
+          </div>
+        </div>
+        <span class="agenda-compteur">{{salles.length}}</span>
+      </div>
+
+      <div class="agenda-ajout">
+        <div class="agenda-nom">
+          <label for="nouvelleSalleNom">Nom de la salle</label>
+          <input id="nouvelleSalleNom" type="text" class="form-control" maxlength="100"
+                 [(ngModel)]="nouvelleSalleNom" placeholder="Ex. Salle polyvalente">
+        </div>
+        <div class="agenda-source">
+          <label for="nouvelleSalleAdresse">Adresse</label>
+          <input id="nouvelleSalleAdresse" type="text" class="form-control" maxlength="500"
+                 [(ngModel)]="nouvelleSalleAdresse" (keydown.enter)="ajouterSalle()"
+                 placeholder="Ex. 8 rue de l’Ouche Dinier, 44400 Rezé">
+        </div>
+        <div class="agenda-couleur">
+          <label for="nouvelleSalleCouleur">Couleur</label>
+          <input id="nouvelleSalleCouleur" type="color" class="form-control form-control-color"
+                 [(ngModel)]="nouvelleSalleCouleur" title="Choisir la couleur de la nouvelle salle">
+        </div>
+        <button type="button" class="btn btn-primary agenda-ajouter" [disabled]="salleEnregistrement"
+                (click)="ajouterSalle()">
+          <fa-icon [icon]="faPlus"></fa-icon>
+          Ajouter
+        </button>
+      </div>
+
+      <div *ngIf="salles.length > 0" class="agenda-liste">
+        <div *ngFor="let salle of salles; let index = index" class="agenda-ligne">
+          <span class="agenda-apercu" [style.background-color]="salle.couleur" aria-hidden="true"></span>
+          <div class="agenda-nom">
+            <label [for]="'salleNom' + index">Nom</label>
+            <input [id]="'salleNom' + index" type="text" class="form-control" maxlength="100"
+                   [(ngModel)]="salle.nom">
+          </div>
+          <div class="agenda-source">
+            <label [for]="'salleAdresse' + index">Adresse</label>
+            <input [id]="'salleAdresse' + index" type="text" class="form-control" maxlength="500"
+                   [(ngModel)]="salle.adresse">
+          </div>
+          <div class="agenda-couleur">
+            <label [for]="'salleCouleur' + index">Couleur</label>
+            <input [id]="'salleCouleur' + index" type="color" class="form-control form-control-color"
+                   [(ngModel)]="salle.couleur" [title]="'Couleur de la salle ' + (index + 1)">
+          </div>
+          <button type="button" class="btn btn-outline-danger agenda-supprimer" [disabled]="salleEnregistrement"
+                  (click)="supprimerSalle(index)" [attr.aria-label]="'Supprimer la salle ' + (index + 1)">
+            <fa-icon [icon]="faTrash"></fa-icon>
+          </button>
+        </div>
+        <div class="agenda-actions">
+          <small>Les modifications de nom, d’adresse et de couleur sont appliquées après enregistrement.</small>
+          <button type="button" class="btn btn-outline-primary" [disabled]="salleEnregistrement"
+                  (click)="enregistrerSalles()">
+            {{salleEnregistrement ? 'Enregistrement…' : 'Enregistrer les modifications'}}
+          </button>
+        </div>
+      </div>
+
+      <div *ngIf="salles.length === 0 && !salleErreur" class="agenda-vide">
+        Aucune salle n'est configurée pour le moment.
+      </div>
+      <div *ngIf="salleMessage" class="alert alert-success agenda-retour" role="status">{{salleMessage}}</div>
+      <div *ngIf="salleErreur" class="alert alert-danger agenda-retour" role="alert">{{salleErreur}}</div>
+    </section>
+  </div>
+
   <!--div class="col-md-12">
     <div type='button' class="btn btn-block btn-primary" (click)="nouvelleAnnee()">Nouvelle Annee</div>
   </div-->

--- a/client/src/app/page/board-admin/board-admin.component.ts
+++ b/client/src/app/page/board-admin/board-admin.component.ts
@@ -2,9 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { UserService } from '../../_services/user.service';
 import { ParamService } from '../../_services/param.service';
 
-import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText, UserLite } from 'src/app/models';
+import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText, SalleConfiguration, UserLite } from 'src/app/models';
 import { forkJoin } from 'rxjs';
-import { faCalendarDays, faCircleCheck, faCircleXmark, faEnvelope, faPlus, faSquareMinus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCalendarDays, faCircleCheck, faCircleXmark, faEnvelope, faLocationDot, faPlus, faSquareMinus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { AdherentService } from 'src/app/_services/adherent.service';
 import {AuthService} from "../../_services/auth.service";
 import {TokenStorageService} from "../../_services/token-storage.service";
@@ -22,6 +22,7 @@ export class BoardAdminComponent implements OnInit {
   faCircleCheck = faCircleCheck;
   faSquareMinus = faSquareMinus;
   faCalendarDays = faCalendarDays;
+  faLocationDot = faLocationDot;
   faPlus = faPlus;
   faTrash = faTrash;
   paramBooleans: ParamBoolean[] = [];
@@ -33,6 +34,13 @@ export class BoardAdminComponent implements OnInit {
   agendaEnregistrement = false;
   agendaMessage = '';
   agendaErreur = '';
+  salles: SalleConfiguration[] = [];
+  nouvelleSalleNom = '';
+  nouvelleSalleAdresse = '';
+  nouvelleSalleCouleur = '#0F9D58';
+  salleEnregistrement = false;
+  salleMessage = '';
+  salleErreur = '';
   usersLite: UserLite[] = [];
   adminsLite: UserLite[] = [];
   administrateursLite: UserLite[] = [];
@@ -49,6 +57,7 @@ export class BoardAdminComponent implements OnInit {
     this.getAllText()
     this.getAllNumber()
     this.getAgendasGoogle()
+    this.getSalles()
     this.fillLists()
   }
 
@@ -214,6 +223,90 @@ console.log(data)
   private prochaineCouleur(): string {
     const palette = ['#4285F4', '#DB4437', '#F4B400', '#0F9D58', '#AB47BC', '#00ACC1'];
     return palette[this.agendasGoogle.length % palette.length];
+  }
+
+  getSalles(): void {
+    this.paramService.getSalles().subscribe({
+      next: salles => this.salles = salles,
+      error: () => this.salleErreur = 'La liste des salles n’a pas pu être chargée.'
+    });
+  }
+
+  ajouterSalle(): void {
+    const nom = this.nouvelleSalleNom.trim();
+    const adresse = this.nouvelleSalleAdresse.trim();
+    this.salleErreur = '';
+    this.salleMessage = '';
+    if (!nom || !adresse) {
+      this.salleErreur = 'Saisissez le nom et l’adresse de la salle.';
+      return;
+    }
+    this.salleEnregistrement = true;
+    this.paramService.createSalle({ nom, adresse, couleur: this.nouvelleSalleCouleur }).subscribe({
+      next: salle => {
+        this.salles = [...this.salles, salle].sort((a, b) => a.nom.localeCompare(b.nom, 'fr'));
+        this.nouvelleSalleNom = '';
+        this.nouvelleSalleAdresse = '';
+        this.nouvelleSalleCouleur = this.prochaineCouleurSalle();
+        this.salleEnregistrement = false;
+        this.salleMessage = 'Salle ajoutée.';
+      },
+      error: response => this.afficherErreurSalle(response)
+    });
+  }
+
+  supprimerSalle(index: number): void {
+    const salle = this.salles[index];
+    if (salle.id == null || this.salleEnregistrement) {
+      return;
+    }
+    this.salleEnregistrement = true;
+    this.salleErreur = '';
+    this.salleMessage = '';
+    this.paramService.deleteSalle(salle.id).subscribe({
+      next: () => {
+        this.salles = this.salles.filter(item => item.id !== salle.id);
+        this.salleEnregistrement = false;
+        this.salleMessage = 'Salle supprimée.';
+      },
+      error: response => this.afficherErreurSalle(response)
+    });
+  }
+
+  enregistrerSalles(): void {
+    if (this.salleEnregistrement) {
+      return;
+    }
+    if (this.salles.some(salle => !salle.nom.trim() || !salle.adresse.trim())) {
+      this.salleErreur = 'Le nom et l’adresse sont obligatoires pour chaque salle.';
+      return;
+    }
+    const misesAJour = this.salles.filter(salle => salle.id != null).map(salle => this.paramService.updateSalle(salle));
+    if (misesAJour.length === 0) {
+      return;
+    }
+    this.salleEnregistrement = true;
+    this.salleErreur = '';
+    this.salleMessage = '';
+    forkJoin(misesAJour).subscribe({
+      next: salles => {
+        this.salles = salles.sort((a, b) => a.nom.localeCompare(b.nom, 'fr'));
+        this.salleEnregistrement = false;
+        this.salleMessage = 'Salles enregistrées.';
+      },
+      error: response => this.afficherErreurSalle(response)
+    });
+  }
+
+  private afficherErreurSalle(response: any): void {
+    this.salleEnregistrement = false;
+    this.salleErreur = response?.error?.message || response?.error?.detail
+      || 'La configuration des salles n’a pas pu être enregistrée.';
+  }
+
+  private prochaineCouleurSalle(): string {
+    const palette = ['#0F9D58', '#4285F4', '#DB4437', '#F4B400', '#AB47BC', '#00ACC1'];
+    return palette[this.salles.length % palette.length];
   }
   updateParamBoolean(param: ParamBoolean) {
     this.paramService.saveBoolean(param).subscribe(

--- a/client/src/app/page/board-admin/board-admin.component.ts
+++ b/client/src/app/page/board-admin/board-admin.component.ts
@@ -2,9 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { UserService } from '../../_services/user.service';
 import { ParamService } from '../../_services/param.service';
 
-import { ParamBoolean, ParamNumber, ParamText, UserLite } from 'src/app/models';
-import { Observable } from 'rxjs';
-import { faEnvelope, faCircleQuestion, faCircleXmark, faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { AgendaGoogleConfiguration, ParamBoolean, ParamNumber, ParamText, UserLite } from 'src/app/models';
+import { forkJoin } from 'rxjs';
+import { faCalendarDays, faCircleCheck, faCircleXmark, faEnvelope, faPlus, faSquareMinus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { AdherentService } from 'src/app/_services/adherent.service';
 import {AuthService} from "../../_services/auth.service";
 import {TokenStorageService} from "../../_services/token-storage.service";
@@ -21,8 +21,18 @@ export class BoardAdminComponent implements OnInit {
   faCircleXmark = faCircleXmark;
   faCircleCheck = faCircleCheck;
   faSquareMinus = faSquareMinus;
+  faCalendarDays = faCalendarDays;
+  faPlus = faPlus;
+  faTrash = faTrash;
   paramBooleans: ParamBoolean[] = [];
   paramTexts: ParamText[] = [];
+  agendasGoogle: AgendaGoogleConfiguration[] = [];
+  nouvelAgendaNom = '';
+  nouvelAgendaSource = '';
+  nouvelAgendaCouleur = '#4285F4';
+  agendaEnregistrement = false;
+  agendaMessage = '';
+  agendaErreur = '';
   usersLite: UserLite[] = [];
   adminsLite: UserLite[] = [];
   administrateursLite: UserLite[] = [];
@@ -38,6 +48,7 @@ export class BoardAdminComponent implements OnInit {
     this.getAllBoolean()
     this.getAllText()
     this.getAllNumber()
+    this.getAgendasGoogle()
     this.fillLists()
   }
 
@@ -108,6 +119,102 @@ console.log(data)
       }
     );
   }
+
+  getAgendasGoogle(): void {
+    this.paramService.getAgendasGoogle().subscribe({
+      next: agendas => this.agendasGoogle = agendas,
+      error: () => this.agendaErreur = "La configuration des agendas n'a pas pu être chargée."
+    });
+  }
+
+  ajouterAgenda(): void {
+    const nom = this.nouvelAgendaNom.trim();
+    const source = this.nouvelAgendaSource.trim();
+    this.agendaErreur = '';
+    this.agendaMessage = '';
+    if (!nom || !source) {
+      this.agendaErreur = "Saisissez un nom et l'identifiant ou l'URL publique du Google Agenda.";
+      return;
+    }
+    if (this.agendasGoogle.length >= 10) {
+      this.agendaErreur = "Le nombre d'agendas Google est limité à 10.";
+      return;
+    }
+    this.agendaEnregistrement = true;
+    this.paramService.createAgendaGoogle({
+      nom,
+      source,
+      couleur: this.nouvelAgendaCouleur
+    }).subscribe({
+      next: agenda => {
+        this.agendasGoogle = [...this.agendasGoogle, agenda].sort((a, b) => a.nom.localeCompare(b.nom, 'fr'));
+        this.nouvelAgendaNom = '';
+        this.nouvelAgendaSource = '';
+        this.nouvelAgendaCouleur = this.prochaineCouleur();
+        this.agendaEnregistrement = false;
+        this.agendaMessage = 'Agenda ajouté.';
+      },
+      error: response => this.afficherErreurAgenda(response)
+    });
+  }
+
+  supprimerAgenda(index: number): void {
+    const agenda = this.agendasGoogle[index];
+    if (agenda.id == null || this.agendaEnregistrement) {
+      return;
+    }
+    this.agendaEnregistrement = true;
+    this.agendaErreur = '';
+    this.agendaMessage = '';
+    this.paramService.deleteAgendaGoogle(agenda.id).subscribe({
+      next: () => {
+        this.agendasGoogle = this.agendasGoogle.filter(item => item.id !== agenda.id);
+        this.agendaEnregistrement = false;
+        this.agendaMessage = 'Agenda supprimé.';
+      },
+      error: response => this.afficherErreurAgenda(response)
+    });
+  }
+
+  enregistrerAgendas(): void {
+    if (this.agendaEnregistrement) {
+      return;
+    }
+    if (this.agendasGoogle.some(agenda => !agenda.nom.trim() || !agenda.source.trim())) {
+      this.agendaErreur = "Le nom et l'identifiant public sont obligatoires pour chaque agenda.";
+      return;
+    }
+    this.agendaEnregistrement = true;
+    this.agendaErreur = '';
+    this.agendaMessage = '';
+    const misesAJour = this.agendasGoogle
+      .filter(agenda => agenda.id != null)
+      .map(agenda => this.paramService.updateAgendaGoogle(agenda));
+    if (misesAJour.length === 0) {
+      this.agendaEnregistrement = false;
+      return;
+    }
+    forkJoin(misesAJour).subscribe({
+      next: agendas => {
+        this.agendasGoogle = agendas.sort((a, b) => a.nom.localeCompare(b.nom, 'fr'));
+        this.agendaEnregistrement = false;
+        this.agendaMessage = 'Agendas enregistrés.';
+      },
+      error: response => this.afficherErreurAgenda(response)
+    });
+  }
+
+  private afficherErreurAgenda(response: any): void {
+    this.agendaEnregistrement = false;
+    this.agendaErreur = response?.error?.message
+      || response?.error?.detail
+      || "La configuration des agendas n'a pas pu être enregistrée.";
+  }
+
+  private prochaineCouleur(): string {
+    const palette = ['#4285F4', '#DB4437', '#F4B400', '#0F9D58', '#AB47BC', '#00ACC1'];
+    return palette[this.agendasGoogle.length % palette.length];
+  }
   updateParamBoolean(param: ParamBoolean) {
     this.paramService.saveBoolean(param).subscribe(
       data => {
@@ -145,7 +252,7 @@ console.log(data)
   getAllText() {
     this.paramService.getAllText().subscribe(
       data => {
-        this.paramTexts = data;
+        this.paramTexts = data.filter(param => param.paramName !== 'Google_Agendas');
 
       },
       err => {

--- a/client/src/app/page/board-user/board-user.component.html
+++ b/client/src/app/page/board-user/board-user.component.html
@@ -59,6 +59,8 @@
   </div>
 </div>
 
+<app-calendrier [tribuUuid]="tribu.uuid"></app-calendrier>
+
 
 
 

--- a/client/src/app/page/login/login.component.css
+++ b/client/src/app/page/login/login.component.css
@@ -52,9 +52,9 @@
 
 .calendrier-mois {
   color: var(--encre);
-  font-size: 1.2rem;
+  font-size: 1.35rem;
   font-weight: 750;
-  margin: 1.35rem 0 0.7rem;
+  margin: 0;
   text-transform: capitalize;
 }
 
@@ -150,26 +150,53 @@
   white-space: nowrap;
 }
 
+.icone-etat-calendrier {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.icone-etat-calendrier.etat-programmee {
+  color: #0d6efd;
+}
+
+.icone-etat-calendrier.etat-annulee {
+  color: #dc3545;
+}
+
+.icone-etat-calendrier.etat-realisee {
+  color: #198754;
+}
+
+.icone-etat-calendrier.etat-modifiee {
+  color: #fd7e14;
+}
+
 .seance-resume.etat-programmee,
 .etat-seance.etat-programmee {
-  background: #e6f5f2;
-  border-color: var(--vert-alod);
-  color: #245d55;
+  background: color-mix(in srgb, var(--agenda-color, var(--vert-alod)) 14%, white);
+  border-color: var(--agenda-color, var(--vert-alod));
+  color: #354044;
 }
 
 .seance-resume.etat-realisee,
 .etat-seance.etat-realisee {
-  background: #e9edf9;
-  border-color: #6f7cc3;
-  color: #394783;
+  background: color-mix(in srgb, var(--agenda-color, #6f7cc3) 14%, white);
+  border-color: var(--agenda-color, #6f7cc3);
+  color: #354044;
 }
 
 .seance-resume.etat-annulee,
 .etat-seance.etat-annulee {
-  background: #fdebec;
-  border-color: var(--rouge-alod);
-  color: #963d3f;
-  text-decoration: line-through;
+  background: color-mix(in srgb, var(--agenda-color, var(--rouge-alod)) 14%, white);
+  border-color: var(--agenda-color, var(--rouge-alod));
+  color: #354044;
+}
+
+.seance-resume.etat-modifiee,
+.etat-seance.etat-modifiee {
+  background: color-mix(in srgb, var(--agenda-color, #fd7e14) 14%, white);
+  border-color: var(--agenda-color, #fd7e14);
+  color: #354044;
 }
 
 .seance-resume.source-google,
@@ -278,6 +305,11 @@
   white-space: pre-line;
 }
 
+.detail-lien {
+  margin-top: 0.45rem;
+  overflow-wrap: anywhere;
+}
+
 :host ::ng-deep .detail-commentaire img {
   height: auto;
   max-width: 100%;
@@ -337,8 +369,7 @@
 }
 
 @media (max-width: 767px) {
-  .calendrier-entete,
-  .legende-agendas {
+  .calendrier-entete {
     align-items: stretch;
     flex-direction: column;
   }

--- a/client/src/app/page/login/login.component.css
+++ b/client/src/app/page/login/login.component.css
@@ -174,9 +174,9 @@
 
 .seance-resume.source-google,
 .etat-seance.source-google {
-  background: #fff3db;
-  border-color: #d29438;
-  color: #765011;
+  background: color-mix(in srgb, var(--agenda-color, #d29438) 14%, white);
+  border-color: var(--agenda-color, #d29438);
+  color: #354044;
 }
 
 .seances-supplementaires {
@@ -184,15 +184,33 @@
   font-weight: 700;
 }
 
-.detail-jour {
-  background: #f7f9f9;
-  border-radius: 12px;
-  margin-top: 1rem;
+.popup-jour-fond {
+  align-items: center;
+  background: rgba(22, 31, 34, 0.58);
+  display: flex;
+  inset: 0;
+  justify-content: center;
   padding: 1rem;
+  position: fixed;
+  z-index: 1050;
+}
+
+.popup-jour {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 24px 70px rgba(17, 28, 32, 0.32);
+  max-height: min(80vh, 720px);
+  max-width: 760px;
+  overflow: hidden;
+  padding: 1.2rem;
+  width: 100%;
 }
 
 .detail-jour-entete {
+  align-items: flex-start;
+  border-bottom: 1px solid #dce4e5;
   margin-bottom: 0.75rem;
+  padding-bottom: 0.75rem;
 }
 
 .detail-jour-entete h3 {
@@ -201,8 +219,33 @@
   text-transform: capitalize;
 }
 
-.detail-jour-entete > span {
+.detail-jour-entete span {
   font-size: 0.78rem;
+}
+
+.popup-jour-fermer {
+  align-items: center;
+  background: #f1f5f4;
+  border: 0;
+  border-radius: 50%;
+  color: var(--encre);
+  display: inline-flex;
+  flex: 0 0 36px;
+  font-size: 1.5rem;
+  height: 36px;
+  justify-content: center;
+  line-height: 1;
+}
+
+.popup-jour-fermer:hover,
+.popup-jour-fermer:focus-visible {
+  background: var(--vert-pale);
+  outline: 2px solid var(--vert-alod);
+}
+
+.popup-jour-liste {
+  max-height: calc(min(80vh, 720px) - 95px);
+  overflow-y: auto;
 }
 
 .detail-seance {
@@ -216,50 +259,75 @@
   font-weight: 800;
 }
 
-.detail-seance div {
+.detail-contenu {
   display: flex;
   flex-direction: column;
 }
 
-.detail-seance div span,
+.detail-contenu span,
 .detail-vide {
   font-size: 0.78rem;
 }
 
+.detail-commentaire {
+  background: #f7f9f9;
+  border-left: 3px solid var(--agenda-color, var(--vert-alod));
+  border-radius: 4px;
+  margin: 0.45rem 0 0;
+  padding: 0.55rem 0.7rem;
+  white-space: pre-line;
+}
+
+:host ::ng-deep .detail-commentaire img {
+  height: auto;
+  max-width: 100%;
+}
+
+:host ::ng-deep .detail-commentaire a {
+  overflow-wrap: anywhere;
+}
+
 .etat-seance {
+  align-self: start;
   border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 750;
   padding: 0.28rem 0.55rem;
 }
 
-.google-agenda-form label {
-  color: var(--encre);
-  font-weight: 700;
-  margin-top: 1rem;
-}
-
-.sources-google {
+.legende-agendas {
   border-top: 1px solid #dce4e5;
+  display: flex;
+  gap: 1rem;
   margin-top: 1rem;
+  padding-top: 1rem;
 }
 
-.google-agenda-form textarea {
-  border-radius: 10px;
+.legende-titre {
+  color: var(--encre);
+  font-size: 0.78rem;
+  font-weight: 800;
 }
 
-.google-agenda-actions {
-  align-items: flex-end;
-  margin-top: 0.75rem;
+.legende-agendas-liste {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.8rem;
 }
 
-.google-agenda-actions small {
-  color: #68767b;
+.legende-agenda {
+  align-items: center;
+  display: flex;
+  gap: 0.35rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.google-agenda-actions .btn {
-  border-radius: 10px;
-  flex: 0 0 auto;
+.legende-couleur {
+  border-radius: 50%;
+  flex: 0 0 10px;
+  height: 10px;
 }
 
 .google-agenda-vide {
@@ -270,7 +338,7 @@
 
 @media (max-width: 767px) {
   .calendrier-entete,
-  .google-agenda-actions {
+  .legende-agendas {
     align-items: stretch;
     flex-direction: column;
   }
@@ -289,9 +357,5 @@
 
   .detail-horaire {
     grid-column: 1 / -1;
-  }
-
-  .google-agenda-actions .btn {
-    width: 100%;
   }
 }

--- a/client/src/app/page/login/login.component.css
+++ b/client/src/app/page/login/login.component.css
@@ -1,0 +1,297 @@
+.calendriers-accueil {
+  --vert-alod: #5cbbaf;
+  --vert-pale: #eaf7f4;
+  --rouge-alod: #ed6567;
+  --encre: #263338;
+  margin: 2rem 0 3rem;
+}
+
+.calendrier-card {
+  border: 0;
+  border-radius: 18px;
+  background: #fff;
+  padding: clamp(1rem, 2.5vw, 2rem);
+  box-shadow: 0 14px 36px rgba(38, 51, 56, 0.12);
+}
+
+.calendrier-entete,
+.detail-jour-entete,
+.google-agenda-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.calendrier-entete h2 {
+  color: var(--encre);
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  margin: 0.2rem 0;
+}
+
+.calendrier-entete p {
+  margin: 0;
+}
+
+.calendrier-surtitre {
+  color: #387e75;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.calendrier-navigation {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.calendrier-navigation .btn {
+  min-width: 42px;
+  border-radius: 10px;
+}
+
+.calendrier-mois {
+  color: var(--encre);
+  font-size: 1.2rem;
+  font-weight: 750;
+  margin: 1.35rem 0 0.7rem;
+  text-transform: capitalize;
+}
+
+.calendrier-tableau {
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.calendrier-semaine,
+.calendrier-grille {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  min-width: 720px;
+}
+
+.calendrier-semaine {
+  background: var(--encre);
+  border-radius: 12px 12px 0 0;
+  color: #fff;
+  font-weight: 800;
+  text-align: center;
+}
+
+.calendrier-semaine > div {
+  padding: 0.65rem 0.25rem;
+}
+
+.calendrier-grille {
+  border-left: 1px solid #dce4e5;
+  border-top: 1px solid #dce4e5;
+}
+
+.calendrier-jour {
+  background: #fff;
+  border-bottom: 1px solid #dce4e5;
+  border-right: 1px solid #dce4e5;
+  cursor: pointer;
+  min-height: 118px;
+  padding: 0.45rem;
+}
+
+.calendrier-jour:hover,
+.calendrier-jour:focus-visible {
+  background: #f4fbf9;
+  box-shadow: inset 0 0 0 2px var(--vert-alod);
+}
+
+.calendrier-jour.hors-mois {
+  background: #f6f7f7;
+  color: #9ca7aa;
+}
+
+.calendrier-jour.jour-selectionne {
+  background: var(--vert-pale);
+  box-shadow: inset 0 0 0 2px var(--vert-alod);
+}
+
+.numero-jour {
+  font-weight: 800;
+  line-height: 25px;
+  margin: 0 0 0.35rem auto;
+  text-align: center;
+  width: 25px;
+}
+
+.jour-actuel .numero-jour {
+  background: var(--rouge-alod);
+  border-radius: 50%;
+  color: #fff;
+}
+
+.seances-du-jour {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.seance-resume {
+  border-left: 3px solid var(--vert-alod);
+  border-radius: 4px;
+  display: flex;
+  font-size: 0.68rem;
+  gap: 0.3rem;
+  padding: 0.25rem 0.3rem;
+}
+
+.seance-resume span {
+  font-variant-numeric: tabular-nums;
+}
+
+.seance-resume strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seance-resume.etat-programmee,
+.etat-seance.etat-programmee {
+  background: #e6f5f2;
+  border-color: var(--vert-alod);
+  color: #245d55;
+}
+
+.seance-resume.etat-realisee,
+.etat-seance.etat-realisee {
+  background: #e9edf9;
+  border-color: #6f7cc3;
+  color: #394783;
+}
+
+.seance-resume.etat-annulee,
+.etat-seance.etat-annulee {
+  background: #fdebec;
+  border-color: var(--rouge-alod);
+  color: #963d3f;
+  text-decoration: line-through;
+}
+
+.seance-resume.source-google,
+.etat-seance.source-google {
+  background: #fff3db;
+  border-color: #d29438;
+  color: #765011;
+}
+
+.seances-supplementaires {
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.detail-jour {
+  background: #f7f9f9;
+  border-radius: 12px;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.detail-jour-entete {
+  margin-bottom: 0.75rem;
+}
+
+.detail-jour-entete h3 {
+  font-size: 1rem;
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.detail-jour-entete > span {
+  font-size: 0.78rem;
+}
+
+.detail-seance {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 100px 1fr auto;
+  padding: 0.55rem 0;
+}
+
+.detail-horaire {
+  font-weight: 800;
+}
+
+.detail-seance div {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-seance div span,
+.detail-vide {
+  font-size: 0.78rem;
+}
+
+.etat-seance {
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 750;
+  padding: 0.28rem 0.55rem;
+}
+
+.google-agenda-form label {
+  color: var(--encre);
+  font-weight: 700;
+  margin-top: 1rem;
+}
+
+.sources-google {
+  border-top: 1px solid #dce4e5;
+  margin-top: 1rem;
+}
+
+.google-agenda-form textarea {
+  border-radius: 10px;
+}
+
+.google-agenda-actions {
+  align-items: flex-end;
+  margin-top: 0.75rem;
+}
+
+.google-agenda-actions small {
+  color: #68767b;
+}
+
+.google-agenda-actions .btn {
+  border-radius: 10px;
+  flex: 0 0 auto;
+}
+
+.google-agenda-vide {
+  background: #f7f9f9;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+@media (max-width: 767px) {
+  .calendrier-entete,
+  .google-agenda-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .calendrier-navigation {
+    justify-content: space-between;
+  }
+
+  .calendrier-navigation .aujourd-hui {
+    flex: 1;
+  }
+
+  .detail-seance {
+    grid-template-columns: 1fr auto;
+  }
+
+  .detail-horaire {
+    grid-column: 1 / -1;
+  }
+
+  .google-agenda-actions .btn {
+    width: 100%;
+  }
+}

--- a/client/src/app/page/login/login.component.html
+++ b/client/src/app/page/login/login.component.html
@@ -212,6 +212,10 @@
     </div>
   </div>
 
+  <app-calendrier></app-calendrier>
+
+  <!-- Ancien rendu conservé temporairement à titre de référence ; l'affichage est assuré par app-calendrier. -->
+  <!--
   <section class="calendriers-accueil" aria-labelledby="titre-calendrier-seances">
     <div class="card calendrier-card">
       <div class="calendrier-entete">
@@ -330,4 +334,5 @@
       </div>
     </div>
   </section>
+  -->
 </div>

--- a/client/src/app/page/login/login.component.html
+++ b/client/src/app/page/login/login.component.html
@@ -215,11 +215,7 @@
   <section class="calendriers-accueil" aria-labelledby="titre-calendrier-seances">
     <div class="card calendrier-card">
       <div class="calendrier-entete">
-        <div>
-          <span class="calendrier-surtitre">Vie de l'association</span>
-          <h2 id="titre-calendrier-seances">Calendrier des séances</h2>
-          <p>Consultez les séances de l'association et les événements de vos Google Agendas publics.</p>
-        </div>
+        <div class="calendrier-mois" id="titre-calendrier-seances" aria-live="polite">{{libelleMois}}</div>
         <div class="calendrier-navigation" aria-label="Navigation dans le calendrier">
           <button type="button" class="btn btn-outline-secondary" (click)="changerMois(-1)"
                   aria-label="Mois précédent">‹</button>
@@ -230,8 +226,6 @@
                   aria-label="Mois suivant">›</button>
         </div>
       </div>
-
-      <div class="calendrier-mois" aria-live="polite">{{libelleMois}}</div>
 
       <div *ngIf="erreurCalendrier" class="alert alert-warning mb-3" role="alert">
         {{erreurCalendrier}}
@@ -263,26 +257,21 @@
             <div *ngFor="let evenement of jour.evenements | slice:0:3"
                  class="seance-resume"
                  [ngClass]="classeEvenement(evenement)"
-                 [style.--agenda-color]="couleurAgenda(evenement)"
+                 [style.--agenda-color]="couleurEvenement(evenement)"
                  [title]="heureEvenement(evenement) + ' · ' + evenement.titre">
               <span>{{heureEvenement(evenement)}}</span>
               <strong>{{evenement.titre}}</strong>
+              <fa-icon *ngIf="evenement.source === 'SEANCE'" class="icone-etat-calendrier"
+                       [ngClass]="classeEtat(evenement.etatSeance)"
+                       [icon]="iconeEtat(evenement.etatSeance)"
+                       [title]="etatLibelle(evenement.etatSeance)"
+                       [attr.aria-label]="etatLibelle(evenement.etatSeance)"></fa-icon>
             </div>
             <span *ngIf="jour.evenements.length > 3" class="seances-supplementaires">
               + {{jour.evenements.length - 3}} autre(s)
             </span>
           </div>
           </div>
-        </div>
-      </div>
-
-      <div *ngIf="agendasGoogle.length > 0" class="legende-agendas" aria-label="Couleurs des Google Agendas">
-        <span class="legende-titre">Google Agendas</span>
-        <div class="legende-agendas-liste">
-          <span *ngFor="let agenda of agendasGoogle" class="legende-agenda" [title]="agenda.source">
-            <span class="legende-couleur" [style.background-color]="agenda.couleur" aria-hidden="true"></span>
-            {{agenda.nom}}
-          </span>
         </div>
       </div>
 
@@ -311,22 +300,28 @@
           </div>
           <div class="popup-jour-liste">
             <article *ngFor="let evenement of jourSelectionne.evenements" class="detail-seance"
-                     [style.--agenda-color]="couleurAgenda(evenement)">
+                     [style.--agenda-color]="couleurEvenement(evenement)">
               <span class="detail-horaire" *ngIf="!evenement.journeeEntiere">
                 {{heure(evenement.debut)}} – {{heure(evenement.fin)}}
               </span>
               <span class="detail-horaire" *ngIf="evenement.journeeEntiere">Toute la journée</span>
               <div class="detail-contenu">
                 <strong>{{evenement.titre}}</strong>
-                <span *ngIf="evenement.lieu" class="detail-lieu">{{evenement.lieu}}</span>
+                <span *ngIf="evenement.lieu" class="detail-lieu">
+                  {{evenement.lieu}}<span *ngIf="lienAdresseSalle(evenement)"> — </span>
+                  <a *ngIf="lienAdresseSalle(evenement)" [href]="lienAdresseSalle(evenement)" target="_blank"
+                     rel="noopener noreferrer">{{evenement.adresseSalle}}</a>
+                </span>
                 <div
                   *ngIf="evenement.commentaire"
                   class="detail-commentaire"
                   [innerHTML]="evenement.commentaire">
                 </div>
+                <a *ngIf="lienActivite(evenement)" class="detail-lien" [href]="lienActivite(evenement)" target="_blank"
+                   rel="noopener noreferrer">Voir l'activité</a>
               </div>
               <span class="etat-seance" [ngClass]="classeEvenement(evenement)"
-                    [style.--agenda-color]="couleurAgenda(evenement)">
+                    [style.--agenda-color]="couleurEvenement(evenement)">
                 {{sourceEvenement(evenement)}}
               </span>
             </article>

--- a/client/src/app/page/login/login.component.html
+++ b/client/src/app/page/login/login.component.html
@@ -59,6 +59,9 @@
     <div *ngIf="!newInscription" class="col-md-6">
       <div *ngIf="!oublieMDP" class="card card-container">
         <h1 class="center">Page de connexion</h1>
+        <div *ngIf="sessionExpiree" class="alert alert-warning" role="alert">
+          Votre session a expiré. Reconnectez-vous pour poursuivre vos modifications.
+        </div>
         <form *ngIf="!isLoggedIn" name="form" (ngSubmit)="f.form.valid && onSubmit()" #f="ngForm" novalidate>
           <div class="form-group">
             <label for="username">Email</label>
@@ -260,6 +263,7 @@
             <div *ngFor="let evenement of jour.evenements | slice:0:3"
                  class="seance-resume"
                  [ngClass]="classeEvenement(evenement)"
+                 [style.--agenda-color]="couleurAgenda(evenement)"
                  [title]="heureEvenement(evenement) + ' · ' + evenement.titre">
               <span>{{heureEvenement(evenement)}}</span>
               <strong>{{evenement.titre}}</strong>
@@ -272,39 +276,13 @@
         </div>
       </div>
 
-      <div *ngIf="jourSelectionne" class="detail-jour" aria-live="polite">
-        <div class="detail-jour-entete">
-          <h3>{{libelleJourSelectionne}}</h3>
-          <span>{{jourSelectionne.evenements.length}} événement(s)</span>
-        </div>
-        <div *ngIf="jourSelectionne.evenements.length === 0" class="detail-vide">
-          Aucun événement programmé ce jour-là.
-        </div>
-        <div *ngFor="let evenement of jourSelectionne.evenements" class="detail-seance">
-          <span class="detail-horaire" *ngIf="!evenement.journeeEntiere">
-            {{heure(evenement.debut)}} – {{heure(evenement.fin)}}
+      <div *ngIf="agendasGoogle.length > 0" class="legende-agendas" aria-label="Couleurs des Google Agendas">
+        <span class="legende-titre">Google Agendas</span>
+        <div class="legende-agendas-liste">
+          <span *ngFor="let agenda of agendasGoogle" class="legende-agenda" [title]="agenda.source">
+            <span class="legende-couleur" [style.background-color]="agenda.couleur" aria-hidden="true"></span>
+            {{agenda.nom}}
           </span>
-          <span class="detail-horaire" *ngIf="evenement.journeeEntiere">Toute la journée</span>
-          <div>
-            <strong>{{evenement.titre}}</strong>
-            <span *ngIf="evenement.lieu">{{evenement.lieu}}</span>
-          </div>
-          <span class="etat-seance" [ngClass]="classeEvenement(evenement)">
-            {{sourceEvenement(evenement)}}
-          </span>
-        </div>
-      </div>
-
-      <div class="google-agenda-form sources-google">
-        <label for="googleAgendaSources">Identifiants ou URLs publiques — un agenda par ligne</label>
-        <textarea id="googleAgendaSources" name="googleAgendaSources" rows="3" class="form-control"
-                  [(ngModel)]="googleAgendaSources"
-                  placeholder="https://calendar.google.com/calendar/..."></textarea>
-        <div class="google-agenda-actions">
-          <small>Les agendas privés doivent d'abord être rendus publics dans Google Agenda.</small>
-          <button type="button" class="btn btn-primary" (click)="afficherGoogleAgendas()">
-            Intégrer au calendrier
-          </button>
         </div>
       </div>
 
@@ -312,8 +290,48 @@
         {{googleAgendaErreur}}
       </div>
       <div *ngIf="googleAgendaIds.length === 0 && !googleAgendaErreur" class="google-agenda-vide">
-        Aucun agenda Google n'est configuré. Un administrateur peut définir les agendas par défaut avec le paramètre
-        <code>Google_Agendas</code>.
+        Aucun agenda Google n'est configuré pour le moment.
+      </div>
+
+      <div *ngIf="popupJourOuverte && jourSelectionne" class="popup-jour-fond"
+           (click)="fermerPopupJour()">
+        <section class="popup-jour" role="dialog" aria-modal="true"
+                 [attr.aria-label]="'Événements du ' + libelleJourSelectionne"
+                 (click)="$event.stopPropagation()">
+          <div class="detail-jour-entete">
+            <div>
+              <h3>{{libelleJourSelectionne}}</h3>
+              <span>{{jourSelectionne.evenements.length}} événement(s)</span>
+            </div>
+            <button type="button" class="popup-jour-fermer" aria-label="Fermer la popup"
+                    (click)="fermerPopupJour()">×</button>
+          </div>
+          <div *ngIf="jourSelectionne.evenements.length === 0" class="detail-vide">
+            Aucun événement programmé ce jour-là.
+          </div>
+          <div class="popup-jour-liste">
+            <article *ngFor="let evenement of jourSelectionne.evenements" class="detail-seance"
+                     [style.--agenda-color]="couleurAgenda(evenement)">
+              <span class="detail-horaire" *ngIf="!evenement.journeeEntiere">
+                {{heure(evenement.debut)}} – {{heure(evenement.fin)}}
+              </span>
+              <span class="detail-horaire" *ngIf="evenement.journeeEntiere">Toute la journée</span>
+              <div class="detail-contenu">
+                <strong>{{evenement.titre}}</strong>
+                <span *ngIf="evenement.lieu" class="detail-lieu">{{evenement.lieu}}</span>
+                <div
+                  *ngIf="evenement.commentaire"
+                  class="detail-commentaire"
+                  [innerHTML]="evenement.commentaire">
+                </div>
+              </div>
+              <span class="etat-seance" [ngClass]="classeEvenement(evenement)"
+                    [style.--agenda-color]="couleurAgenda(evenement)">
+                {{sourceEvenement(evenement)}}
+              </span>
+            </article>
+          </div>
+        </section>
       </div>
     </div>
   </section>

--- a/client/src/app/page/login/login.component.html
+++ b/client/src/app/page/login/login.component.html
@@ -208,3 +208,113 @@
       </div>
     </div>
   </div>
+
+  <section class="calendriers-accueil" aria-labelledby="titre-calendrier-seances">
+    <div class="card calendrier-card">
+      <div class="calendrier-entete">
+        <div>
+          <span class="calendrier-surtitre">Vie de l'association</span>
+          <h2 id="titre-calendrier-seances">Calendrier des séances</h2>
+          <p>Consultez les séances de l'association et les événements de vos Google Agendas publics.</p>
+        </div>
+        <div class="calendrier-navigation" aria-label="Navigation dans le calendrier">
+          <button type="button" class="btn btn-outline-secondary" (click)="changerMois(-1)"
+                  aria-label="Mois précédent">‹</button>
+          <button type="button" class="btn btn-outline-secondary aujourd-hui" (click)="revenirAujourdhui()">
+            Aujourd'hui
+          </button>
+          <button type="button" class="btn btn-outline-secondary" (click)="changerMois(1)"
+                  aria-label="Mois suivant">›</button>
+        </div>
+      </div>
+
+      <div class="calendrier-mois" aria-live="polite">{{libelleMois}}</div>
+
+      <div *ngIf="erreurCalendrier" class="alert alert-warning mb-3" role="alert">
+        {{erreurCalendrier}}
+      </div>
+      <div *ngIf="chargementCalendrier" class="calendrier-chargement" aria-live="polite">
+        Chargement des séances…
+      </div>
+
+      <div class="calendrier-tableau">
+        <div class="calendrier-semaine" aria-hidden="true">
+          <div *ngFor="let jourSemaine of joursSemaine">{{jourSemaine}}</div>
+        </div>
+
+        <div class="calendrier-grille" role="grid" [attr.aria-label]="'Calendrier ' + libelleMois">
+          <div *ngFor="let jour of calendrier"
+             class="calendrier-jour"
+             [class.hors-mois]="!jour.dansLeMois"
+             [class.jour-actuel]="jour.aujourdhui"
+             [class.jour-selectionne]="jourSelectionne?.iso === jour.iso"
+             role="gridcell"
+             tabindex="0"
+             [attr.aria-label]="jour.date | date:'fullDate':'':'fr-FR'"
+             [attr.aria-selected]="jourSelectionne?.iso === jour.iso"
+             (click)="selectionnerJour(jour)"
+             (keydown.enter)="selectionnerJour(jour)"
+             (keydown.space)="$event.preventDefault(); selectionnerJour(jour)">
+          <div class="numero-jour">{{jour.numero}}</div>
+          <div class="seances-du-jour">
+            <div *ngFor="let evenement of jour.evenements | slice:0:3"
+                 class="seance-resume"
+                 [ngClass]="classeEvenement(evenement)"
+                 [title]="heureEvenement(evenement) + ' · ' + evenement.titre">
+              <span>{{heureEvenement(evenement)}}</span>
+              <strong>{{evenement.titre}}</strong>
+            </div>
+            <span *ngIf="jour.evenements.length > 3" class="seances-supplementaires">
+              + {{jour.evenements.length - 3}} autre(s)
+            </span>
+          </div>
+          </div>
+        </div>
+      </div>
+
+      <div *ngIf="jourSelectionne" class="detail-jour" aria-live="polite">
+        <div class="detail-jour-entete">
+          <h3>{{libelleJourSelectionne}}</h3>
+          <span>{{jourSelectionne.evenements.length}} événement(s)</span>
+        </div>
+        <div *ngIf="jourSelectionne.evenements.length === 0" class="detail-vide">
+          Aucun événement programmé ce jour-là.
+        </div>
+        <div *ngFor="let evenement of jourSelectionne.evenements" class="detail-seance">
+          <span class="detail-horaire" *ngIf="!evenement.journeeEntiere">
+            {{heure(evenement.debut)}} – {{heure(evenement.fin)}}
+          </span>
+          <span class="detail-horaire" *ngIf="evenement.journeeEntiere">Toute la journée</span>
+          <div>
+            <strong>{{evenement.titre}}</strong>
+            <span *ngIf="evenement.lieu">{{evenement.lieu}}</span>
+          </div>
+          <span class="etat-seance" [ngClass]="classeEvenement(evenement)">
+            {{sourceEvenement(evenement)}}
+          </span>
+        </div>
+      </div>
+
+      <div class="google-agenda-form sources-google">
+        <label for="googleAgendaSources">Identifiants ou URLs publiques — un agenda par ligne</label>
+        <textarea id="googleAgendaSources" name="googleAgendaSources" rows="3" class="form-control"
+                  [(ngModel)]="googleAgendaSources"
+                  placeholder="https://calendar.google.com/calendar/..."></textarea>
+        <div class="google-agenda-actions">
+          <small>Les agendas privés doivent d'abord être rendus publics dans Google Agenda.</small>
+          <button type="button" class="btn btn-primary" (click)="afficherGoogleAgendas()">
+            Intégrer au calendrier
+          </button>
+        </div>
+      </div>
+
+      <div *ngIf="googleAgendaErreur" class="alert alert-warning mt-3 mb-0" role="alert">
+        {{googleAgendaErreur}}
+      </div>
+      <div *ngIf="googleAgendaIds.length === 0 && !googleAgendaErreur" class="google-agenda-vide">
+        Aucun agenda Google n'est configuré. Un administrateur peut définir les agendas par défaut avec le paramètre
+        <code>Google_Agendas</code>.
+      </div>
+    </div>
+  </section>
+</div>

--- a/client/src/app/page/login/login.component.ts
+++ b/client/src/app/page/login/login.component.ts
@@ -4,9 +4,32 @@ import { TokenStorageService } from '../../_services/token-storage.service';
 import { Router } from '@angular/router';
 import { ParamTransmissionService } from 'src/app/_helpers/transmission.service';
 import { faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus } from '@fortawesome/free-solid-svg-icons';
-import { Subscription } from 'rxjs';
+import { catchError, forkJoin, of, Subscription } from 'rxjs';
 import { ParamService } from 'src/app/_services/param.service';
 import { ToastrService } from 'ngx-toastr';
+import { ActiviteService } from 'src/app/_services/activite.service';
+import { EvenementGoogleAgenda, SeanceCalendrier } from 'src/app/models/seance';
+
+interface EvenementCalendrier {
+  id: string;
+  titre: string;
+  lieu: string | null;
+  debut: string;
+  fin: string;
+  source: 'SEANCE' | 'GOOGLE';
+  journeeEntiere: boolean;
+  agenda?: string;
+  etatSeance?: SeanceCalendrier['etatSeance'];
+}
+
+interface JourCalendrier {
+  date: Date;
+  iso: string;
+  numero: number;
+  dansLeMois: boolean;
+  aujourdhui: boolean;
+  evenements: EvenementCalendrier[];
+}
 
 @Component({
   selector: 'app-login',
@@ -34,6 +57,15 @@ export class LoginComponent implements OnInit {
   messageInscription: string = ""
   textMaintenance: string = ""
   textRGPD: string = ""
+  calendrier: JourCalendrier[] = [];
+  jourSelectionne: JourCalendrier | null = null;
+  moisAffiche = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+  chargementCalendrier = false;
+  erreurCalendrier = '';
+  googleAgendaSources = '';
+  googleAgendaIds: string[] = [];
+  googleAgendaErreur = '';
+  readonly joursSemaine = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'];
 
   maintenance: Boolean = false;
   isSuccessful = false;
@@ -49,17 +81,23 @@ export class LoginComponent implements OnInit {
     private authService: AuthService,
     private tokenStorage: TokenStorageService,
     public router: Router,
-    public paramService: ParamService) { }
+    public paramService: ParamService,
+    private activiteService: ActiviteService) { }
 
   ngOnInit(): void {
 
+    this.chargerCalendrier();
+
     this.paramService.getAllText().subscribe({
       next: (data) => {
-        this.messageConnexion = data.filter(param => param.paramName == "Text_Accueil")[0].paramValue;
-        this.messageInscription = data.filter(param => param.paramName == "Text_Inscription")[0].paramValue;
-        this.textMaintenance = data.filter(param => param.paramName == "Text_Maintenance")[0].paramValue;
-
-        this.textRGPD = data.filter(param => param.paramName == "RGPD")[0].paramValue;
+        this.messageConnexion = data.find(param => param.paramName == "Text_Accueil")?.paramValue || '';
+        this.messageInscription = data.find(param => param.paramName == "Text_Inscription")?.paramValue || '';
+        this.textMaintenance = data.find(param => param.paramName == "Text_Maintenance")?.paramValue || '';
+        this.textRGPD = data.find(param => param.paramName == "RGPD")?.paramValue || '';
+        this.googleAgendaSources = data.find(param => param.paramName == "Google_Agendas")?.paramValue || '';
+        if (this.googleAgendaSources.trim()) {
+          this.afficherGoogleAgendas(false);
+        }
 
       },
       error: (error) => {
@@ -99,6 +137,186 @@ export class LoginComponent implements OnInit {
       });
 
 
+  }
+
+  get libelleMois(): string {
+    return new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric' })
+      .format(this.moisAffiche);
+  }
+
+  get libelleJourSelectionne(): string {
+    if (!this.jourSelectionne) {
+      return '';
+    }
+    return new Intl.DateTimeFormat('fr-FR', {
+      weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
+    }).format(this.jourSelectionne.date);
+  }
+
+  changerMois(decalage: number): void {
+    this.moisAffiche = new Date(
+      this.moisAffiche.getFullYear(), this.moisAffiche.getMonth() + decalage, 1);
+    this.chargerCalendrier();
+  }
+
+  revenirAujourdhui(): void {
+    const maintenant = new Date();
+    this.moisAffiche = new Date(maintenant.getFullYear(), maintenant.getMonth(), 1);
+    this.chargerCalendrier();
+  }
+
+  selectionnerJour(jour: JourCalendrier): void {
+    this.jourSelectionne = jour;
+  }
+
+  chargerCalendrier(): void {
+    const debut = this.premierJourVisible();
+    const fin = new Date(debut);
+    fin.setDate(fin.getDate() + 41);
+    this.chargementCalendrier = true;
+    this.erreurCalendrier = '';
+    this.googleAgendaErreur = '';
+    const dateDebut = this.dateIso(debut);
+    const dateFin = this.dateIso(fin);
+    const seances$ = this.activiteService.getCalendrier(dateDebut, dateFin).pipe(catchError(() => {
+      this.erreurCalendrier = "Le calendrier des séances n'est pas disponible pour le moment.";
+      return of([] as SeanceCalendrier[]);
+    }));
+    const google$ = this.googleAgendaIds.length > 0
+      ? this.activiteService.getCalendrierGoogle(dateDebut, dateFin, this.googleAgendaIds).pipe(catchError(() => {
+          this.googleAgendaErreur = "Les agendas Google publics ne sont pas disponibles pour le moment.";
+          return of({ evenements: [] as EvenementGoogleAgenda[], erreurs: [] });
+        }))
+      : of({ evenements: [] as EvenementGoogleAgenda[], erreurs: [] });
+
+    forkJoin({ seances: seances$, google: google$ }).subscribe(({ seances, google }) => {
+      this.googleAgendaErreur ||= google.erreurs.join(' ');
+      this.construireCalendrier(debut, seances, google.evenements);
+      this.chargementCalendrier = false;
+    });
+  }
+
+  heure(dateHeure: string): string {
+    return dateHeure?.substring(11, 16) || '';
+  }
+
+  etatLibelle(etat?: SeanceCalendrier['etatSeance']): string {
+    return etat === 'ANNULEE' ? 'Annulée' : etat === 'REALISEE' ? 'Réalisée' : 'Programmée';
+  }
+
+  classeEtat(etat?: SeanceCalendrier['etatSeance']): string {
+    return `etat-${(etat || 'PROGRAMMEE').toLowerCase()}`;
+  }
+
+  afficherGoogleAgendas(afficherErreur = true): void {
+    const agendas = this.extraireGoogleAgendaIds(this.googleAgendaSources);
+    this.googleAgendaErreur = '';
+    if (agendas.length === 0) {
+      this.googleAgendaIds = [];
+      if (afficherErreur) {
+        this.googleAgendaErreur = "Saisissez l'identifiant ou l'URL publique d'au moins un Google Agenda.";
+      }
+      this.chargerCalendrier();
+      return;
+    }
+    this.googleAgendaIds = agendas;
+    this.chargerCalendrier();
+  }
+
+  private premierJourVisible(): Date {
+    const premierDuMois = new Date(this.moisAffiche.getFullYear(), this.moisAffiche.getMonth(), 1);
+    const decalageDepuisLundi = (premierDuMois.getDay() + 6) % 7;
+    const debut = new Date(premierDuMois);
+    debut.setDate(debut.getDate() - decalageDepuisLundi);
+    return debut;
+  }
+
+  private construireCalendrier(debut: Date, seances: SeanceCalendrier[], google: EvenementGoogleAgenda[]): void {
+    const evenementsParJour = new Map<string, EvenementCalendrier[]>();
+    const evenements: EvenementCalendrier[] = [
+      ...seances.map(seance => ({
+        id: `seance-${seance.id}`,
+        titre: seance.activiteNom,
+        lieu: seance.salle,
+        debut: seance.debut,
+        fin: seance.fin,
+        source: 'SEANCE' as const,
+        journeeEntiere: false,
+        etatSeance: seance.etatSeance
+      })),
+      ...google.map(evenement => ({ ...evenement, source: 'GOOGLE' as const }))
+    ];
+    evenements.forEach(evenement => {
+      let date = new Date(`${evenement.debut.substring(0, 10)}T12:00:00`);
+      const dernierJour = new Date(`${evenement.fin.substring(0, 10)}T12:00:00`);
+      if (evenement.journeeEntiere) dernierJour.setDate(dernierJour.getDate() - 1);
+      do {
+        const iso = this.dateIso(date);
+        evenementsParJour.set(iso, [...(evenementsParJour.get(iso) || []), evenement]);
+        date.setDate(date.getDate() + 1);
+      } while (date <= dernierJour);
+    });
+
+    const aujourdHui = this.dateIso(new Date());
+    this.calendrier = Array.from({ length: 42 }, (_, index) => {
+      const date = new Date(debut);
+      date.setDate(debut.getDate() + index);
+      const iso = this.dateIso(date);
+      return {
+        date,
+        iso,
+        numero: date.getDate(),
+        dansLeMois: date.getMonth() === this.moisAffiche.getMonth(),
+        aujourdhui: iso === aujourdHui,
+        evenements: (evenementsParJour.get(iso) || []).sort((a, b) => a.debut.localeCompare(b.debut))
+      };
+    });
+
+    const ancienneSelection = this.jourSelectionne?.iso;
+    this.jourSelectionne = this.calendrier.find(jour => jour.iso === ancienneSelection)
+      || this.calendrier.find(jour => jour.iso === aujourdHui)
+      || this.calendrier.find(jour => jour.dansLeMois && jour.evenements.length > 0)
+      || this.calendrier.find(jour => jour.dansLeMois)
+      || null;
+  }
+
+  private dateIso(date: Date): string {
+    const mois = String(date.getMonth() + 1).padStart(2, '0');
+    const jour = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${mois}-${jour}`;
+  }
+
+  private extraireGoogleAgendaIds(sources: string): string[] {
+    const ids = sources.split(/\r?\n|;/).flatMap(source => {
+      const valeur = source.trim();
+      if (!valeur) {
+        return [];
+      }
+      try {
+        const url = new URL(valeur);
+        if (url.protocol !== 'https:' || url.hostname !== 'calendar.google.com') {
+          return [];
+        }
+        const sourcesUrl = url.searchParams.getAll('src');
+        return sourcesUrl.length > 0 ? sourcesUrl : [valeur];
+      } catch {
+        return [valeur];
+      }
+    });
+
+    return [...new Set(ids.filter(id => id.length <= 500 && !/[<>"']/.test(id)))];
+  }
+
+  heureEvenement(evenement: EvenementCalendrier): string {
+    return evenement.journeeEntiere ? 'Journée' : this.heure(evenement.debut);
+  }
+
+  classeEvenement(evenement: EvenementCalendrier): string {
+    return evenement.source === 'GOOGLE' ? 'source-google' : this.classeEtat(evenement.etatSeance);
+  }
+
+  sourceEvenement(evenement: EvenementCalendrier): string {
+    return evenement.source === 'GOOGLE' ? `Google · ${evenement.agenda}` : this.etatLibelle(evenement.etatSeance);
   }
   onSubmitInscritpion(): void{
     const { username, password } = this.form;

--- a/client/src/app/page/login/login.component.ts
+++ b/client/src/app/page/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../../_services/auth.service';
 import { TokenStorageService } from '../../_services/token-storage.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ParamTransmissionService } from 'src/app/_helpers/transmission.service';
 import { faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { catchError, forkJoin, of, Subscription } from 'rxjs';
@@ -9,16 +9,19 @@ import { ParamService } from 'src/app/_services/param.service';
 import { ToastrService } from 'ngx-toastr';
 import { ActiviteService } from 'src/app/_services/activite.service';
 import { EvenementGoogleAgenda, SeanceCalendrier } from 'src/app/models/seance';
+import { AgendaGoogleConfiguration } from 'src/app/models';
 
 interface EvenementCalendrier {
   id: string;
   titre: string;
   lieu: string | null;
+  commentaire?: string | null;
   debut: string;
   fin: string;
   source: 'SEANCE' | 'GOOGLE';
   journeeEntiere: boolean;
   agenda?: string;
+  agendaSource?: string;
   etatSeance?: SeanceCalendrier['etatSeance'];
 }
 
@@ -59,12 +62,14 @@ export class LoginComponent implements OnInit {
   textRGPD: string = ""
   calendrier: JourCalendrier[] = [];
   jourSelectionne: JourCalendrier | null = null;
+  popupJourOuverte = false;
   moisAffiche = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
   chargementCalendrier = false;
   erreurCalendrier = '';
-  googleAgendaSources = '';
+  agendasGoogle: AgendaGoogleConfiguration[] = [];
   googleAgendaIds: string[] = [];
   googleAgendaErreur = '';
+  sessionExpiree = false;
   readonly joursSemaine = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'];
 
   maintenance: Boolean = false;
@@ -81,12 +86,15 @@ export class LoginComponent implements OnInit {
     private authService: AuthService,
     private tokenStorage: TokenStorageService,
     public router: Router,
+    private route: ActivatedRoute,
     public paramService: ParamService,
     private activiteService: ActiviteService) { }
 
   ngOnInit(): void {
 
-    this.chargerCalendrier();
+    this.sessionExpiree = this.route.snapshot.queryParamMap.get('sessionExpiree') === '1';
+
+    this.chargerConfigurationAgendas();
 
     this.paramService.getAllText().subscribe({
       next: (data) => {
@@ -94,11 +102,6 @@ export class LoginComponent implements OnInit {
         this.messageInscription = data.find(param => param.paramName == "Text_Inscription")?.paramValue || '';
         this.textMaintenance = data.find(param => param.paramName == "Text_Maintenance")?.paramValue || '';
         this.textRGPD = data.find(param => param.paramName == "RGPD")?.paramValue || '';
-        this.googleAgendaSources = data.find(param => param.paramName == "Google_Agendas")?.paramValue || '';
-        if (this.googleAgendaSources.trim()) {
-          this.afficherGoogleAgendas(false);
-        }
-
       },
       error: (error) => {
       }
@@ -139,6 +142,22 @@ export class LoginComponent implements OnInit {
 
   }
 
+  chargerConfigurationAgendas(): void {
+    this.paramService.getAgendasGoogle().subscribe({
+      next: agendas => {
+        this.agendasGoogle = agendas;
+        this.googleAgendaIds = agendas.map(agenda => agenda.source);
+        this.chargerCalendrier();
+      },
+      error: () => {
+        this.agendasGoogle = [];
+        this.googleAgendaIds = [];
+        this.chargerCalendrier();
+        this.googleAgendaErreur = "La configuration des agendas Google n'est pas disponible pour le moment.";
+      }
+    });
+  }
+
   get libelleMois(): string {
     return new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric' })
       .format(this.moisAffiche);
@@ -167,6 +186,11 @@ export class LoginComponent implements OnInit {
 
   selectionnerJour(jour: JourCalendrier): void {
     this.jourSelectionne = jour;
+    this.popupJourOuverte = true;
+  }
+
+  fermerPopupJour(): void {
+    this.popupJourOuverte = false;
   }
 
   chargerCalendrier(): void {
@@ -206,21 +230,6 @@ export class LoginComponent implements OnInit {
 
   classeEtat(etat?: SeanceCalendrier['etatSeance']): string {
     return `etat-${(etat || 'PROGRAMMEE').toLowerCase()}`;
-  }
-
-  afficherGoogleAgendas(afficherErreur = true): void {
-    const agendas = this.extraireGoogleAgendaIds(this.googleAgendaSources);
-    this.googleAgendaErreur = '';
-    if (agendas.length === 0) {
-      this.googleAgendaIds = [];
-      if (afficherErreur) {
-        this.googleAgendaErreur = "Saisissez l'identifiant ou l'URL publique d'au moins un Google Agenda.";
-      }
-      this.chargerCalendrier();
-      return;
-    }
-    this.googleAgendaIds = agendas;
-    this.chargerCalendrier();
   }
 
   private premierJourVisible(): Date {
@@ -286,27 +295,6 @@ export class LoginComponent implements OnInit {
     return `${date.getFullYear()}-${mois}-${jour}`;
   }
 
-  private extraireGoogleAgendaIds(sources: string): string[] {
-    const ids = sources.split(/\r?\n|;/).flatMap(source => {
-      const valeur = source.trim();
-      if (!valeur) {
-        return [];
-      }
-      try {
-        const url = new URL(valeur);
-        if (url.protocol !== 'https:' || url.hostname !== 'calendar.google.com') {
-          return [];
-        }
-        const sourcesUrl = url.searchParams.getAll('src');
-        return sourcesUrl.length > 0 ? sourcesUrl : [valeur];
-      } catch {
-        return [valeur];
-      }
-    });
-
-    return [...new Set(ids.filter(id => id.length <= 500 && !/[<>"']/.test(id)))];
-  }
-
   heureEvenement(evenement: EvenementCalendrier): string {
     return evenement.journeeEntiere ? 'Journée' : this.heure(evenement.debut);
   }
@@ -315,8 +303,21 @@ export class LoginComponent implements OnInit {
     return evenement.source === 'GOOGLE' ? 'source-google' : this.classeEtat(evenement.etatSeance);
   }
 
+  couleurAgenda(evenement: EvenementCalendrier): string {
+    if (evenement.source !== 'GOOGLE') {
+      return '';
+    }
+    return this.agendasGoogle.find(agenda => agenda.source === evenement.agendaSource)?.couleur || '#D29438';
+  }
+
+  nomAgenda(evenement: EvenementCalendrier): string {
+    return this.agendasGoogle.find(agenda => agenda.source === evenement.agendaSource)?.nom
+      || evenement.agenda
+      || 'Agenda Google';
+  }
+
   sourceEvenement(evenement: EvenementCalendrier): string {
-    return evenement.source === 'GOOGLE' ? `Google · ${evenement.agenda}` : this.etatLibelle(evenement.etatSeance);
+    return evenement.source === 'GOOGLE' ? `Google · ${this.nomAgenda(evenement)}` : this.etatLibelle(evenement.etatSeance);
   }
   onSubmitInscritpion(): void{
     const { username, password } = this.form;

--- a/client/src/app/page/login/login.component.ts
+++ b/client/src/app/page/login/login.component.ts
@@ -3,7 +3,7 @@ import { AuthService } from '../../_services/auth.service';
 import { TokenStorageService } from '../../_services/token-storage.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ParamTransmissionService } from 'src/app/_helpers/transmission.service';
-import { faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { faBook, faCheck, faClock, faCloudDownloadAlt, faPencilSquare, faScaleBalanced, faSquareMinus, faSquarePlus, faTriangleExclamation, faUserPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { catchError, forkJoin, of, Subscription } from 'rxjs';
 import { ParamService } from 'src/app/_services/param.service';
 import { ToastrService } from 'ngx-toastr';
@@ -15,6 +15,7 @@ interface EvenementCalendrier {
   id: string;
   titre: string;
   lieu: string | null;
+  adresseSalle?: string | null;
   commentaire?: string | null;
   debut: string;
   fin: string;
@@ -22,6 +23,8 @@ interface EvenementCalendrier {
   journeeEntiere: boolean;
   agenda?: string;
   agendaSource?: string;
+  couleurSalle?: string | null;
+  lien?: string | null;
   etatSeance?: SeanceCalendrier['etatSeance'];
 }
 
@@ -46,7 +49,10 @@ export class LoginComponent implements OnInit {
     password: null
   };
 
-  faCircleCheck = faCircleCheck;
+  faClock = faClock;
+  faXmark = faXmark;
+  faCheck = faCheck;
+  faTriangleExclamation = faTriangleExclamation;
   subscription = new Subscription()
   isLoggedIn = false;
   isLoginFailed = false;
@@ -225,7 +231,17 @@ export class LoginComponent implements OnInit {
   }
 
   etatLibelle(etat?: SeanceCalendrier['etatSeance']): string {
-    return etat === 'ANNULEE' ? 'Annulée' : etat === 'REALISEE' ? 'Réalisée' : 'Programmée';
+    return etat === 'ANNULEE' ? 'Annulée'
+      : etat === 'REALISEE' ? 'Réalisée'
+      : etat === 'MODIFIEE' ? 'Modifiée'
+      : 'Programmée';
+  }
+
+  iconeEtat(etat?: SeanceCalendrier['etatSeance']) {
+    return etat === 'ANNULEE' ? this.faXmark
+      : etat === 'REALISEE' ? this.faCheck
+      : etat === 'MODIFIEE' ? this.faTriangleExclamation
+      : this.faClock;
   }
 
   classeEtat(etat?: SeanceCalendrier['etatSeance']): string {
@@ -247,6 +263,10 @@ export class LoginComponent implements OnInit {
         id: `seance-${seance.id}`,
         titre: seance.activiteNom,
         lieu: seance.salle,
+        adresseSalle: seance.adresseSalle,
+        commentaire: seance.commentaire,
+        couleurSalle: seance.couleurSalle,
+        lien: seance.lien,
         debut: seance.debut,
         fin: seance.fin,
         source: 'SEANCE' as const,
@@ -303,9 +323,9 @@ export class LoginComponent implements OnInit {
     return evenement.source === 'GOOGLE' ? 'source-google' : this.classeEtat(evenement.etatSeance);
   }
 
-  couleurAgenda(evenement: EvenementCalendrier): string {
-    if (evenement.source !== 'GOOGLE') {
-      return '';
+  couleurEvenement(evenement: EvenementCalendrier): string {
+    if (evenement.source === 'SEANCE') {
+      return evenement.couleurSalle || '#5CBBaf';
     }
     return this.agendasGoogle.find(agenda => agenda.source === evenement.agendaSource)?.couleur || '#D29438';
   }
@@ -314,6 +334,21 @@ export class LoginComponent implements OnInit {
     return this.agendasGoogle.find(agenda => agenda.source === evenement.agendaSource)?.nom
       || evenement.agenda
       || 'Agenda Google';
+  }
+
+  lienActivite(evenement: EvenementCalendrier): string | null {
+    if (evenement.source !== 'SEANCE' || !evenement.lien?.trim()) {
+      return null;
+    }
+    const lien = evenement.lien.trim();
+    return /^https?:\/\//i.test(lien) ? lien : `https://${lien}`;
+  }
+
+  lienAdresseSalle(evenement: EvenementCalendrier): string | null {
+    if (!evenement.adresseSalle?.trim()) {
+      return null;
+    }
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(evenement.adresseSalle.trim())}`;
   }
 
   sourceEvenement(evenement: EvenementCalendrier): string {

--- a/client/src/app/template/calendrier/calendrier.component.html
+++ b/client/src/app/template/calendrier/calendrier.component.html
@@ -1,0 +1,41 @@
+<section class="calendriers-accueil" aria-labelledby="titre-calendrier-seances">
+  <div class="card calendrier-card">
+    <div class="calendrier-entete">
+      <div>
+        <span class="calendrier-surtitre">Vie de l'association</span>
+        <h2 id="titre-calendrier-seances">Calendrier des séances</h2>
+        <p>Consultez les séances de l'association et les événements de vos Google Agendas publics.</p>
+      </div>
+      <div class="calendrier-navigation" aria-label="Navigation dans le calendrier">
+        <button type="button" class="btn btn-outline-secondary" (click)="changerMois(-1)" aria-label="Mois précédent">‹</button>
+        <button type="button" class="btn btn-outline-secondary aujourd-hui" (click)="revenirAujourdhui()">Aujourd'hui</button>
+        <button type="button" class="btn btn-outline-secondary" (click)="changerMois(1)" aria-label="Mois suivant">›</button>
+      </div>
+    </div>
+    <div class="calendrier-mois" aria-live="polite">{{libelleMois}}</div>
+    <div *ngIf="erreurCalendrier" class="alert alert-warning mb-3" role="alert">{{erreurCalendrier}}</div>
+    <div *ngIf="chargementCalendrier" class="calendrier-chargement" aria-live="polite">Chargement des séances…</div>
+    <div class="calendrier-tableau">
+      <div class="calendrier-semaine" aria-hidden="true"><div *ngFor="let jourSemaine of joursSemaine">{{jourSemaine}}</div></div>
+      <div class="calendrier-grille" role="grid" [attr.aria-label]="'Calendrier ' + libelleMois">
+        <div *ngFor="let jour of calendrier" class="calendrier-jour" [class.hors-mois]="!jour.dansLeMois" [class.jour-actuel]="jour.aujourdhui" [class.jour-selectionne]="jourSelectionne?.iso === jour.iso" role="gridcell" tabindex="0" [attr.aria-label]="jour.date | date:'fullDate':'':'fr-FR'" [attr.aria-selected]="jourSelectionne?.iso === jour.iso" (click)="selectionnerJour(jour)" (keydown.enter)="selectionnerJour(jour)" (keydown.space)="$event.preventDefault(); selectionnerJour(jour)">
+          <div class="numero-jour">{{jour.numero}}</div>
+          <div class="seances-du-jour">
+            <div *ngFor="let evenement of jour.evenements | slice:0:3" class="seance-resume" [ngClass]="classeEvenement(evenement)" [style.--agenda-color]="couleurEvenement(evenement)" [title]="heureEvenement(evenement) + ' · ' + evenement.titre"><span>{{heureEvenement(evenement)}}</span><strong>{{evenement.titre}}</strong><fa-icon *ngIf="evenement.source === 'SEANCE'" class="icone-etat-calendrier" [ngClass]="classeEtat(evenement.etatSeance)" [icon]="iconeEtat(evenement.etatSeance)" [title]="etatLibelle(evenement.etatSeance)" [attr.aria-label]="etatLibelle(evenement.etatSeance)"></fa-icon></div>
+            <span *ngIf="jour.evenements.length > 3" class="seances-supplementaires">+ {{jour.evenements.length - 3}} autre(s)</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div *ngIf="agendasGoogle.length > 0" class="legende-agendas" aria-label="Couleurs des Google Agendas"><span class="legende-titre">Google Agendas</span><div class="legende-agendas-liste"><span *ngFor="let agenda of agendasGoogle" class="legende-agenda" [title]="agenda.source"><span class="legende-couleur" [style.background-color]="agenda.couleur" aria-hidden="true"></span>{{agenda.nom}}</span></div></div>
+    <div *ngIf="googleAgendaErreur" class="alert alert-warning mt-3 mb-0" role="alert">{{googleAgendaErreur}}</div>
+    <div *ngIf="googleAgendaIds.length === 0 && !googleAgendaErreur" class="google-agenda-vide">Aucun agenda Google n'est configuré pour le moment.</div>
+    <div *ngIf="popupJourOuverte && jourSelectionne" class="popup-jour-fond" (click)="fermerPopupJour()">
+      <section class="popup-jour" role="dialog" aria-modal="true" [attr.aria-label]="'Événements du ' + libelleJourSelectionne" (click)="$event.stopPropagation()">
+        <div class="detail-jour-entete"><div><h3>{{libelleJourSelectionne}}</h3><span>{{jourSelectionne.evenements.length}} événement(s)</span></div><button type="button" class="popup-jour-fermer" aria-label="Fermer la popup" (click)="fermerPopupJour()">×</button></div>
+        <div *ngIf="jourSelectionne.evenements.length === 0" class="detail-vide">Aucun événement programmé ce jour-là.</div>
+        <div class="popup-jour-liste"><article *ngFor="let evenement of jourSelectionne.evenements" class="detail-seance" [style.--agenda-color]="couleurEvenement(evenement)"><span class="detail-horaire" *ngIf="!evenement.journeeEntiere">{{heure(evenement.debut)}} – {{heure(evenement.fin)}}</span><span class="detail-horaire" *ngIf="evenement.journeeEntiere">Toute la journée</span><div class="detail-contenu"><strong>{{evenement.titre}}</strong><span *ngIf="evenement.lieu" class="detail-lieu">{{evenement.lieu}}<span *ngIf="lienAdresseSalle(evenement)"> — </span><a *ngIf="lienAdresseSalle(evenement)" [href]="lienAdresseSalle(evenement)" target="_blank" rel="noopener noreferrer">{{evenement.adresseSalle}}</a></span><div *ngIf="evenement.commentaire" class="detail-commentaire" [innerHTML]="evenement.commentaire"></div><a *ngIf="lienActivite(evenement)" class="detail-lien" [href]="lienActivite(evenement)" target="_blank" rel="noopener noreferrer">Voir l'activité</a></div><span class="etat-seance" [ngClass]="classeEvenement(evenement)" [style.--agenda-color]="couleurEvenement(evenement)">{{sourceEvenement(evenement)}}</span></article></div>
+      </section>
+    </div>
+  </div>
+</section>

--- a/client/src/app/template/calendrier/calendrier.component.ts
+++ b/client/src/app/template/calendrier/calendrier.component.ts
@@ -1,0 +1,152 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { catchError, forkJoin, of } from 'rxjs';
+import { ActiviteService } from 'src/app/_services/activite.service';
+import { ParamService } from 'src/app/_services/param.service';
+import { AgendaGoogleConfiguration } from 'src/app/models';
+import { EvenementGoogleAgenda, SeanceCalendrier } from 'src/app/models/seance';
+import { faCheck, faClock, faTriangleExclamation, faXmark } from '@fortawesome/free-solid-svg-icons';
+
+interface EvenementCalendrier {
+  id: string;
+  titre: string;
+  lieu: string | null;
+  adresseSalle?: string | null;
+  commentaire?: string | null;
+  debut: string;
+  fin: string;
+  source: 'SEANCE' | 'GOOGLE';
+  journeeEntiere: boolean;
+  agenda?: string;
+  agendaSource?: string;
+  couleurSalle?: string | null;
+  lien?: string | null;
+  etatSeance?: SeanceCalendrier['etatSeance'];
+}
+
+interface JourCalendrier {
+  date: Date;
+  iso: string;
+  numero: number;
+  dansLeMois: boolean;
+  aujourdhui: boolean;
+  evenements: EvenementCalendrier[];
+}
+
+@Component({
+  selector: 'app-calendrier',
+  templateUrl: './calendrier.component.html',
+  styleUrls: ['../../page/login/login.component.css']
+})
+export class CalendrierComponent implements OnInit, OnChanges {
+  @Input() tribuUuid?: string;
+
+  calendrier: JourCalendrier[] = [];
+  jourSelectionne: JourCalendrier | null = null;
+  popupJourOuverte = false;
+  moisAffiche = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+  chargementCalendrier = false;
+  erreurCalendrier = '';
+  agendasGoogle: AgendaGoogleConfiguration[] = [];
+  googleAgendaIds: string[] = [];
+  googleAgendaErreur = '';
+  readonly joursSemaine = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'];
+  faClock = faClock;
+  faXmark = faXmark;
+  faCheck = faCheck;
+  faTriangleExclamation = faTriangleExclamation;
+
+  constructor(private paramService: ParamService, private activiteService: ActiviteService) {}
+
+  ngOnInit(): void { this.chargerConfigurationAgendas(); }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['tribuUuid'] && !changes['tribuUuid'].firstChange && this.agendasGoogle) this.chargerCalendrier();
+  }
+
+  chargerConfigurationAgendas(): void {
+    this.paramService.getAgendasGoogle().subscribe({
+      next: agendas => {
+        this.agendasGoogle = agendas;
+        this.googleAgendaIds = agendas.map(agenda => agenda.source);
+        this.chargerCalendrier();
+      },
+      error: () => {
+        this.agendasGoogle = [];
+        this.googleAgendaIds = [];
+        this.googleAgendaErreur = "La configuration des agendas Google n'est pas disponible pour le moment.";
+        this.chargerCalendrier();
+      }
+    });
+  }
+
+  get libelleMois(): string { return new Intl.DateTimeFormat('fr-FR', { month: 'long', year: 'numeric' }).format(this.moisAffiche); }
+  get libelleJourSelectionne(): string {
+    return this.jourSelectionne ? new Intl.DateTimeFormat('fr-FR', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' }).format(this.jourSelectionne.date) : '';
+  }
+  changerMois(decalage: number): void {
+    this.moisAffiche = new Date(this.moisAffiche.getFullYear(), this.moisAffiche.getMonth() + decalage, 1);
+    this.chargerCalendrier();
+  }
+  revenirAujourdhui(): void {
+    const maintenant = new Date();
+    this.moisAffiche = new Date(maintenant.getFullYear(), maintenant.getMonth(), 1);
+    this.chargerCalendrier();
+  }
+  selectionnerJour(jour: JourCalendrier): void { this.jourSelectionne = jour; this.popupJourOuverte = true; }
+  fermerPopupJour(): void { this.popupJourOuverte = false; }
+
+  chargerCalendrier(): void {
+    const debut = this.premierJourVisible();
+    const fin = new Date(debut); fin.setDate(fin.getDate() + 41);
+    this.chargementCalendrier = true; this.erreurCalendrier = ''; this.googleAgendaErreur = '';
+    const dateDebut = this.dateIso(debut); const dateFin = this.dateIso(fin);
+    const seances$ = this.activiteService.getCalendrier(dateDebut, dateFin, this.tribuUuid).pipe(catchError(() => {
+      this.erreurCalendrier = "Le calendrier des séances n'est pas disponible pour le moment.";
+      return of([] as SeanceCalendrier[]);
+    }));
+    const google$ = this.googleAgendaIds.length ? this.activiteService.getCalendrierGoogle(dateDebut, dateFin, this.googleAgendaIds).pipe(catchError(() => {
+      this.googleAgendaErreur = "Les agendas Google publics ne sont pas disponibles pour le moment.";
+      return of({ evenements: [] as EvenementGoogleAgenda[], erreurs: [] });
+    })) : of({ evenements: [] as EvenementGoogleAgenda[], erreurs: [] });
+    forkJoin({ seances: seances$, google: google$ }).subscribe(({ seances, google }) => {
+      this.googleAgendaErreur ||= google.erreurs.join(' ');
+      this.construireCalendrier(debut, seances, google.evenements);
+      this.chargementCalendrier = false;
+    });
+  }
+
+  heure(dateHeure: string): string { return dateHeure?.substring(11, 16) || ''; }
+  etatLibelle(etat?: SeanceCalendrier['etatSeance']): string { return etat === 'ANNULEE' ? 'Annulée' : etat === 'REALISEE' ? 'Réalisée' : etat === 'MODIFIEE' ? 'Modifiée' : 'Programmée'; }
+  iconeEtat(etat?: SeanceCalendrier['etatSeance']) { return etat === 'ANNULEE' ? this.faXmark : etat === 'REALISEE' ? this.faCheck : etat === 'MODIFIEE' ? this.faTriangleExclamation : this.faClock; }
+  classeEtat(etat?: SeanceCalendrier['etatSeance']): string { return `etat-${(etat || 'PROGRAMMEE').toLowerCase()}`; }
+  heureEvenement(evenement: EvenementCalendrier): string { return evenement.journeeEntiere ? 'Journée' : this.heure(evenement.debut); }
+  classeEvenement(evenement: EvenementCalendrier): string { return evenement.source === 'GOOGLE' ? 'source-google' : this.classeEtat(evenement.etatSeance); }
+  couleurEvenement(evenement: EvenementCalendrier): string { return evenement.source === 'SEANCE' ? evenement.couleurSalle || '#5CBBaf' : this.agendasGoogle.find(a => a.source === evenement.agendaSource)?.couleur || '#D29438'; }
+  nomAgenda(evenement: EvenementCalendrier): string { return this.agendasGoogle.find(a => a.source === evenement.agendaSource)?.nom || evenement.agenda || 'Agenda Google'; }
+  sourceEvenement(evenement: EvenementCalendrier): string { return evenement.source === 'GOOGLE' ? `Google · ${this.nomAgenda(evenement)}` : this.etatLibelle(evenement.etatSeance); }
+  lienActivite(evenement: EvenementCalendrier): string | null { if (evenement.source !== 'SEANCE' || !evenement.lien?.trim()) return null; const lien = evenement.lien.trim(); return /^https?:\/\//i.test(lien) ? lien : `https://${lien}`; }
+  lienAdresseSalle(evenement: EvenementCalendrier): string | null { return evenement.adresseSalle?.trim() ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(evenement.adresseSalle.trim())}` : null; }
+
+  private premierJourVisible(): Date {
+    const premier = new Date(this.moisAffiche.getFullYear(), this.moisAffiche.getMonth(), 1);
+    premier.setDate(premier.getDate() - (premier.getDay() + 6) % 7);
+    return premier;
+  }
+  private construireCalendrier(debut: Date, seances: SeanceCalendrier[], google: EvenementGoogleAgenda[]): void {
+    const parJour = new Map<string, EvenementCalendrier[]>();
+    const evenements: EvenementCalendrier[] = [...seances.map(s => ({ id: `seance-${s.id}`, titre: s.activiteNom, lieu: s.salle, adresseSalle: s.adresseSalle, commentaire: s.commentaire, couleurSalle: s.couleurSalle, lien: s.lien, debut: s.debut, fin: s.fin, source: 'SEANCE' as const, journeeEntiere: false, etatSeance: s.etatSeance })), ...google.map(e => ({ ...e, source: 'GOOGLE' as const }))];
+    evenements.forEach(e => {
+      const date = new Date(`${e.debut.substring(0, 10)}T12:00:00`); const dernier = new Date(`${e.fin.substring(0, 10)}T12:00:00`);
+      if (e.journeeEntiere) dernier.setDate(dernier.getDate() - 1);
+      do { const iso = this.dateIso(date); parJour.set(iso, [...(parJour.get(iso) || []), e]); date.setDate(date.getDate() + 1); } while (date <= dernier);
+    });
+    const aujourdHui = this.dateIso(new Date());
+    this.calendrier = Array.from({ length: 42 }, (_, index) => {
+      const date = new Date(debut); date.setDate(debut.getDate() + index); const iso = this.dateIso(date);
+      return { date, iso, numero: date.getDate(), dansLeMois: date.getMonth() === this.moisAffiche.getMonth(), aujourdhui: iso === aujourdHui, evenements: (parJour.get(iso) || []).sort((a, b) => a.debut.localeCompare(b.debut)) };
+    });
+    const ancienne = this.jourSelectionne?.iso;
+    this.jourSelectionne = this.calendrier.find(j => j.iso === ancienne) || this.calendrier.find(j => j.iso === aujourdHui) || this.calendrier.find(j => j.dansLeMois && j.evenements.length > 0) || this.calendrier.find(j => j.dansLeMois) || null;
+  }
+  private dateIso(date: Date): string { return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`; }
+}

--- a/client/src/app/template/modal-activite/modal.activite.css
+++ b/client/src/app/template/modal-activite/modal.activite.css
@@ -21,3 +21,68 @@
   }
 
   .big-checkbox {width: 40px; height: 20px;}
+
+.seances-section {
+  border-top: 1px solid #dee2e6;
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+}
+
+.planification-seances,
+.ajout-seances {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: .5rem;
+  margin: 0;
+  padding: 1rem;
+}
+
+.planification-seances {
+  border-left: .25rem solid #0d6efd;
+}
+
+.seances-liste {
+  border: 1px solid #dee2e6;
+  border-radius: .5rem;
+  margin-top: 1rem;
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.seances-liste thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.etat-seance {
+  min-width: 9.5rem;
+}
+
+.date-seance {
+  min-width: 10.5rem;
+}
+
+.horaire-seance {
+  min-width: 8.5rem;
+}
+
+.commentaire-seance {
+  min-width: 14rem;
+}
+
+.action-seance {
+  width: 3rem;
+}
+
+.etat-programmee {
+  border-color: #0d6efd;
+}
+
+.etat-realisee {
+  border-color: #198754;
+}
+
+.etat-annulee {
+  border-color: #dc3545;
+}

--- a/client/src/app/template/modal-activite/modal.activite.css
+++ b/client/src/app/template/modal-activite/modal.activite.css
@@ -20,7 +20,21 @@
     margin-left: 5px;
   }
 
-  .big-checkbox {width: 40px; height: 20px;}
+.big-checkbox {width: 40px; height: 20px;}
+
+.selecteur-salle {
+  align-items: center;
+  display: flex;
+  gap: .55rem;
+}
+
+.couleur-salle {
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px #adb5bd;
+  flex: 0 0 20px;
+  height: 20px;
+}
 
 .seances-section {
   border-top: 1px solid #dee2e6;
@@ -85,4 +99,8 @@
 
 .etat-annulee {
   border-color: #dc3545;
+}
+
+.etat-modifiee {
+  border-color: #fd7e14;
 }

--- a/client/src/app/template/modal-activite/modal.activite.html
+++ b/client/src/app/template/modal-activite/modal.activite.html
@@ -51,7 +51,20 @@
 
       <div class="form-group">
         <label for="salle">Salle</label>
-        <input type="text" class="form-control" name="salle" [(ngModel)]="activite.salle" />
+        <div class="selecteur-salle">
+          <span *ngIf="activite.salle" class="couleur-salle" [style.background-color]="activite.salle.couleur"
+                [title]="'Couleur : ' + activite.salle.couleur" aria-hidden="true"></span>
+          <select id="salle" class="form-select" name="salle" [(ngModel)]="activite.salle"
+                  [compareWith]="comparerSalles">
+          <option [ngValue]="undefined">Aucune salle</option>
+          <option *ngFor="let salle of salles" [ngValue]="salle">
+            {{salle.nom}} — {{salle.adresse}} · {{salle.couleur}}
+          </option>
+          </select>
+        </div>
+        <small *ngIf="activite.salle" class="text-muted">
+          La couleur {{activite.salle.couleur}} sera utilisée pour les nouvelles séances dans le calendrier.
+        </small>
       </div>
 
       <div class="form-group">
@@ -297,10 +310,11 @@
                 <select class="form-select form-select-sm" [(ngModel)]="seance.etatSeance"
                         [name]="'etatSeance-' + seance.id" (ngModelChange)="enregistrerEtatSeance(seance)"
                         [disabled]="suppressionSeances.has(seance.id)"
-                        [ngClass]="seance.etatSeance === 'ANNULEE' ? 'etat-annulee' : (seance.etatSeance === 'REALISEE' ? 'etat-realisee' : 'etat-programmee')">
+                        [ngClass]="seance.etatSeance === 'ANNULEE' ? 'etat-annulee' : (seance.etatSeance === 'REALISEE' ? 'etat-realisee' : (seance.etatSeance === 'MODIFIEE' ? 'etat-modifiee' : 'etat-programmee'))">
                   <option value="PROGRAMMEE">Programmée</option>
                   <option value="REALISEE">Réalisée</option>
                   <option value="ANNULEE">Annulée</option>
+                  <option value="MODIFIEE">Modifiée</option>
                 </select>
               </td>
               <td class="commentaire-seance">

--- a/client/src/app/template/modal-activite/modal.activite.html
+++ b/client/src/app/template/modal-activite/modal.activite.html
@@ -39,16 +39,6 @@
         <input type="number" class="form-control" name="tarif" [(ngModel)]="activite.tarif" />
       </div>
 
-      <div ngbDropdown class="d-inline-block">
-        <button type="button" class="btn btn-primary" id="Jour" ngbDropdownToggle>
-          {{activite.jour?activite.jour:'Jour'}}
-        </button>
-        <div ngbDropdownMenu aria-labelledby="Jour">
-          <div ngbDropdownItem *ngFor="let day of  getEnumKeys()"
-               (click)="activite.jour = day">{{day}} </div>
-        </div>
-      </div>
-
       <div class="form-group">
         <label for="horaire">Horaire</label>
         <input type="text" class="form-control" name="horaire" [(ngModel)]="activite.horaire" />
@@ -215,6 +205,132 @@
       </div>
     </div>
   </div>
+
+  <section class="seances-section">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+      <div>
+        <h5 class="mb-1">Séances</h5>
+        <small class="text-muted">Les séances sont créées chaque semaine selon la planification ci-dessous, hors vacances et jours fériés.</small>
+      </div>
+      <span *ngIf="activite.id" class="badge bg-secondary">{{seances.length}} séance(s)</span>
+    </div>
+
+    <div class="row g-2 align-items-end planification-seances mb-3">
+      <div class="col-12">
+        <h6 class="mb-0">Planification hebdomadaire</h6>
+      </div>
+      <div class="col-12 col-sm-4">
+        <label for="jourSeance" class="form-label">Jour</label>
+        <select id="jourSeance" name="jourSeance" class="form-select" [(ngModel)]="activite.jour">
+          <option value="" disabled>Sélectionner un jour</option>
+          <option *ngFor="let jour of joursSemaine" [value]="jour.valeur">{{jour.libelle}}</option>
+        </select>
+      </div>
+      <div class="col-12 col-sm-4">
+        <label for="horaireDebut" class="form-label">Heure de début</label>
+        <input id="horaireDebut" type="time" class="form-control" name="horaireDebut"
+               [(ngModel)]="activite.horaireDebut" />
+      </div>
+      <div class="col-12 col-sm-4">
+        <label for="duree" class="form-label">Durée (minutes)</label>
+        <input id="duree" type="number" min="1" class="form-control" name="duree"
+               [(ngModel)]="activite.duree" />
+      </div>
+    </div>
+
+    <div *ngIf="activite.id; else activiteNonEnregistree">
+      <div class="row g-2 align-items-end ajout-seances">
+        <div class="col-12 col-sm-4">
+          <label for="nombreSeances" class="form-label">Nombre de séances</label>
+          <input id="nombreSeances" name="nombreSeances" type="number" min="1" max="200"
+                 class="form-control" [(ngModel)]="nombreSeances" />
+        </div>
+        <div class="col-12 col-sm-4">
+          <label for="dateDebutSeances" class="form-label">À partir du</label>
+          <input id="dateDebutSeances" name="dateDebutSeances" type="date"
+                 class="form-control" [(ngModel)]="dateDebutSeances" />
+        </div>
+        <div class="col-12 col-sm-4 d-grid">
+          <button type="button" class="btn btn-primary" (click)="ajouterSeances()"
+                  [disabled]="ajoutSeancesEnCours || !dateDebutSeances || nombreSeances < 1 || nombreSeances > 200">
+            {{ajoutSeancesEnCours ? 'Ajout en cours…' : 'Ajouter les séances'}}
+          </button>
+        </div>
+      </div>
+
+      <div *ngIf="chargementSeances" class="text-center text-muted py-4">Chargement des séances…</div>
+
+      <div *ngIf="!chargementSeances && seances.length === 0" class="alert alert-light border mt-3 mb-0">
+        Aucune séance planifiée pour cette activité.
+      </div>
+
+      <div *ngIf="!chargementSeances && seances.length > 0" class="table-responsive seances-liste">
+        <table class="table table-sm table-striped align-middle mb-0">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Heure</th>
+              <th scope="col">État</th>
+              <th scope="col">Commentaire</th>
+              <th scope="col" class="text-center"><span class="visually-hidden">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let seance of seances">
+              <td class="date-seance">
+                <input type="date" class="form-control form-control-sm"
+                       [name]="'dateSeance-' + seance.id" [(ngModel)]="seance.dateEdition"
+                       (ngModelChange)="planifierEnregistrementHoraire(seance)"
+                       (blur)="enregistrerHoraireAuBlur(seance)"
+                       [disabled]="suppressionSeances.has(seance.id)" />
+                <small class="text-muted text-capitalize">{{seance.debut | date:'EEEE'}}</small>
+              </td>
+              <td class="horaire-seance">
+                <input type="time" class="form-control form-control-sm"
+                       [name]="'heureSeance-' + seance.id" [(ngModel)]="seance.heureEdition"
+                       (ngModelChange)="planifierEnregistrementHoraire(seance)"
+                       (blur)="enregistrerHoraireAuBlur(seance)"
+                       [disabled]="suppressionSeances.has(seance.id)" />
+                <small class="text-muted">Fin : {{seance.fin | date:'HH:mm'}}</small>
+              </td>
+              <td class="etat-seance">
+                <select class="form-select form-select-sm" [(ngModel)]="seance.etatSeance"
+                        [name]="'etatSeance-' + seance.id" (ngModelChange)="enregistrerEtatSeance(seance)"
+                        [disabled]="suppressionSeances.has(seance.id)"
+                        [ngClass]="seance.etatSeance === 'ANNULEE' ? 'etat-annulee' : (seance.etatSeance === 'REALISEE' ? 'etat-realisee' : 'etat-programmee')">
+                  <option value="PROGRAMMEE">Programmée</option>
+                  <option value="REALISEE">Réalisée</option>
+                  <option value="ANNULEE">Annulée</option>
+                </select>
+              </td>
+              <td class="commentaire-seance">
+                <input type="text" class="form-control form-control-sm" maxlength="255"
+                       [name]="'commentaireSeance-' + seance.id" [(ngModel)]="seance.commentaire"
+                       (ngModelChange)="planifierEnregistrementCommentaire(seance)"
+                       (blur)="enregistrerCommentaireAuBlur(seance)"
+                       [disabled]="suppressionSeances.has(seance.id)" placeholder="Ajouter un commentaire" />
+                <small *ngIf="enregistrementSeances.has(seance.id)" class="text-muted">Enregistrement…</small>
+              </td>
+              <td class="text-center action-seance">
+                <button type="button" class="btn btn-sm btn-outline-danger" title="Supprimer la séance"
+                        [attr.aria-label]="'Supprimer la séance du ' + (seance.debut | date:'d MMMM y')"
+                        (click)="supprimerSeance(seance)"
+                        [disabled]="suppressionSeances.has(seance.id) || enregistrementSeances.has(seance.id)">
+                  <fa-icon [icon]="faTrash"></fa-icon>
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <ng-template #activiteNonEnregistree>
+      <div class="alert alert-info mb-0">
+        Enregistrez d'abord l'activité, puis rouvrez-la pour ajouter et consulter ses séances.
+      </div>
+    </ng-template>
+  </section>
 
 
 </div>

--- a/client/src/app/template/modal-activite/modal.activite.html
+++ b/client/src/app/template/modal-activite/modal.activite.html
@@ -283,6 +283,7 @@
             <tr>
               <th scope="col">Date</th>
               <th scope="col">Heure</th>
+              <th scope="col">Salle</th>
               <th scope="col">État</th>
               <th scope="col">Commentaire</th>
               <th scope="col" class="text-center"><span class="visually-hidden">Actions</span></th>
@@ -305,6 +306,15 @@
                        (blur)="enregistrerHoraireAuBlur(seance)"
                        [disabled]="suppressionSeances.has(seance.id)" />
                 <small class="text-muted">Fin : {{seance.fin | date:'HH:mm'}}</small>
+              </td>
+              <td class="salle-seance">
+                <select class="form-select form-select-sm" [(ngModel)]="seance.salle"
+                        [name]="'salleSeance-' + seance.id" [compareWith]="comparerSalles"
+                        (ngModelChange)="enregistrerSalleSeance(seance)"
+                        [disabled]="suppressionSeances.has(seance.id)">
+                  <option [ngValue]="undefined">Aucune salle</option>
+                  <option *ngFor="let salle of salles" [ngValue]="salle">{{salle.nom}}</option>
+                </select>
               </td>
               <td class="etat-seance">
                 <select class="form-select form-select-sm" [(ngModel)]="seance.etatSeance"

--- a/client/src/app/template/modal-activite/modal.activite.ts
+++ b/client/src/app/template/modal-activite/modal.activite.ts
@@ -1,10 +1,11 @@
 import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { Activite, Adherent, AdherentLite } from 'src/app/models';
+import { Activite, Adherent, AdherentLite, SalleConfiguration } from 'src/app/models';
 import { Seance } from 'src/app/models/seance';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
 import { AdherentService } from 'src/app/_services/adherent.service';
 import { ActiviteService } from 'src/app/_services/activite.service';
+import { ParamService } from 'src/app/_services/param.service';
 import { faCircleQuestion, faEnvelope, faCircleXmark, faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ToastrService } from 'ngx-toastr';
 
@@ -34,6 +35,7 @@ export class ModalActivite implements OnInit, OnDestroy {
   activite!: Activite;
 
   profs: AdherentLite[] = []
+  salles: SalleConfiguration[] = [];
   seances: Seance[] = [];
   nombreSeances = 1;
   dateDebutSeances = '';
@@ -57,11 +59,13 @@ export class ModalActivite implements OnInit, OnDestroy {
     private toastr: ToastrService,
     private adherentService: AdherentService,
     public activiteService: ActiviteService,
+    private paramService: ParamService,
   ) { }
 
   ngOnInit(): void {
     this.dateDebutSeances = this.aujourdHui();
     this.getProfs();
+    this.getSalles();
     if (this.activite.id) {
       this.getSeances();
     }
@@ -106,6 +110,17 @@ export class ModalActivite implements OnInit, OnDestroy {
       }
     );
 
+  }
+
+  getSalles(): void {
+    this.paramService.getSalles().subscribe({
+      next: salles => this.salles = salles,
+      error: err => this.showError(err.message)
+    });
+  }
+
+  comparerSalles(salleA?: SalleConfiguration, salleB?: SalleConfiguration): boolean {
+    return salleA?.id === salleB?.id;
   }
 
   getSeances() {

--- a/client/src/app/template/modal-activite/modal.activite.ts
+++ b/client/src/app/template/modal-activite/modal.activite.ts
@@ -237,6 +237,25 @@ export class ModalActivite implements OnInit, OnDestroy {
     });
   }
 
+  enregistrerSalleSeance(seance: Seance) {
+    if (!this.activite.id || !seance.id) {
+      return;
+    }
+
+    this.enregistrementSeances.add(seance.id);
+    this.activiteService.modifierSalleSeance(this.activite.id, seance).subscribe({
+      next: data => {
+        seance.salle = data.salle;
+        this.enregistrementSeances.delete(seance.id);
+      },
+      error: err => {
+        this.enregistrementSeances.delete(seance.id);
+        this.getSeances();
+        this.showError(err.message);
+      }
+    });
+  }
+
   planifierEnregistrementHoraire(seance: Seance) {
     const timerExistant = this.horaireTimers.get(seance.id);
     if (timerExistant) {

--- a/client/src/app/template/modal-activite/modal.activite.ts
+++ b/client/src/app/template/modal-activite/modal.activite.ts
@@ -1,19 +1,19 @@
-import { Component, inject, Input, OnInit } from '@angular/core'
+import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { Activite, ActiviteDropDown, Adherent, AdherentLite } from 'src/app/models';
+import { Activite, Adherent, AdherentLite } from 'src/app/models';
+import { Seance } from 'src/app/models/seance';
 import { faExternalLinkSquareAlt } from '@fortawesome/free-solid-svg-icons';
 import { AdherentService } from 'src/app/_services/adherent.service';
 import { ActiviteService } from 'src/app/_services/activite.service';
-import { faCircleQuestion, faEnvelope, faCircleXmark, faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faEnvelope, faCircleXmark, faCloudDownloadAlt, faBook, faScaleBalanced, faPencilSquare, faSquarePlus, faSquareMinus, faCircleCheck, faUserPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ToastrService } from 'ngx-toastr';
-import {DayOfWeek} from "./dayOfWeek";
 
 @Component({
   selector: 'modal',
   templateUrl: './modal.activite.html',
   styleUrls: ['./modal.activite.css']
 })
-export class ModalActivite implements OnInit {
+export class ModalActivite implements OnInit, OnDestroy {
   faCircleQuestion = faCircleQuestion
   faEnvelope = faEnvelope;
   faCircleXmark = faCircleXmark;
@@ -25,6 +25,7 @@ export class ModalActivite implements OnInit {
   faSquareMinus = faSquareMinus;
   faPencilSquare = faPencilSquare;
   faSquarePlus = faSquarePlus;
+  faTrash = faTrash;
 
 
   activeModal = inject(NgbActiveModal);
@@ -33,6 +34,24 @@ export class ModalActivite implements OnInit {
   activite!: Activite;
 
   profs: AdherentLite[] = []
+  seances: Seance[] = [];
+  nombreSeances = 1;
+  dateDebutSeances = '';
+  chargementSeances = false;
+  ajoutSeancesEnCours = false;
+  enregistrementSeances = new Set<number>();
+  suppressionSeances = new Set<number>();
+  private commentaireTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  private horaireTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  readonly joursSemaine = [
+    { valeur: 'MONDAY', libelle: 'Lundi' },
+    { valeur: 'TUESDAY', libelle: 'Mardi' },
+    { valeur: 'WEDNESDAY', libelle: 'Mercredi' },
+    { valeur: 'THURSDAY', libelle: 'Jeudi' },
+    { valeur: 'FRIDAY', libelle: 'Vendredi' },
+    { valeur: 'SATURDAY', libelle: 'Samedi' },
+    { valeur: 'SUNDAY', libelle: 'Dimanche' },
+  ];
 
   constructor(
     private toastr: ToastrService,
@@ -41,8 +60,16 @@ export class ModalActivite implements OnInit {
   ) { }
 
   ngOnInit(): void {
-
+    this.dateDebutSeances = this.aujourdHui();
     this.getProfs();
+    if (this.activite.id) {
+      this.getSeances();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.commentaireTimers.forEach(timer => clearTimeout(timer));
+    this.horaireTimers.forEach(timer => clearTimeout(timer));
   }
 
 
@@ -81,6 +108,192 @@ export class ModalActivite implements OnInit {
 
   }
 
+  getSeances() {
+    this.chargementSeances = true;
+    this.activiteService.getSeances(this.activite.id).subscribe({
+      next: data => {
+        this.seances = this.preparerSeances(data);
+        this.chargementSeances = false;
+      },
+      error: err => {
+        this.chargementSeances = false;
+        this.showError(err.message);
+      }
+    });
+  }
+
+  ajouterSeances() {
+    if (!this.activite.id || !this.dateDebutSeances || this.nombreSeances < 1) {
+      return;
+    }
+
+    this.ajoutSeancesEnCours = true;
+    this.activiteService.ajouterSeances(
+      this.activite.id,
+      this.nombreSeances,
+      this.dateDebutSeances
+    ).subscribe({
+      next: data => {
+        this.seances = this.preparerSeances(data);
+        this.ajoutSeancesEnCours = false;
+        this.toastr.success(
+          `${this.nombreSeances} séance(s) ajoutée(s)`,
+          'Séances enregistrées'
+        );
+      },
+      error: err => {
+        this.ajoutSeancesEnCours = false;
+        this.showError(err.message);
+      }
+    });
+  }
+
+  enregistrerEtatSeance(seance: Seance) {
+    if (!this.activite.id || !seance.id) {
+      return;
+    }
+
+    this.enregistrementSeances.add(seance.id);
+    this.activiteService.modifierEtatSeance(this.activite.id, seance).subscribe({
+      next: () => this.enregistrementSeances.delete(seance.id),
+      error: err => {
+        this.enregistrementSeances.delete(seance.id);
+        this.getSeances();
+        this.showError(err.message);
+      }
+    });
+  }
+
+  enregistrerCommentaireSeance(seance: Seance) {
+    if (!this.activite.id || !seance.id) {
+      return;
+    }
+
+    this.enregistrementSeances.add(seance.id);
+    this.activiteService.modifierCommentaireSeance(this.activite.id, seance).subscribe({
+      next: () => this.enregistrementSeances.delete(seance.id),
+      error: err => {
+        this.enregistrementSeances.delete(seance.id);
+        this.getSeances();
+        this.showError(err.message);
+      }
+    });
+  }
+
+  planifierEnregistrementCommentaire(seance: Seance) {
+    const timerExistant = this.commentaireTimers.get(seance.id);
+    if (timerExistant) {
+      clearTimeout(timerExistant);
+    }
+
+    this.commentaireTimers.set(seance.id, setTimeout(() => {
+      this.commentaireTimers.delete(seance.id);
+      this.enregistrerCommentaireSeance(seance);
+    }, 700));
+  }
+
+  enregistrerCommentaireAuBlur(seance: Seance) {
+    const timerExistant = this.commentaireTimers.get(seance.id);
+    if (timerExistant) {
+      clearTimeout(timerExistant);
+      this.commentaireTimers.delete(seance.id);
+    }
+    this.enregistrerCommentaireSeance(seance);
+  }
+
+  enregistrerHoraireSeance(seance: Seance) {
+    if (!this.activite.id || !seance.id || !seance.dateEdition || !seance.heureEdition) {
+      return;
+    }
+
+    this.enregistrementSeances.add(seance.id);
+    this.activiteService.modifierHoraireSeance(this.activite.id, seance).subscribe({
+      next: data => {
+        seance.debut = data.debut;
+        seance.fin = data.fin;
+        this.preparerSeance(seance);
+        this.enregistrementSeances.delete(seance.id);
+      },
+      error: err => {
+        this.enregistrementSeances.delete(seance.id);
+        this.getSeances();
+        this.showError(err.message);
+      }
+    });
+  }
+
+  planifierEnregistrementHoraire(seance: Seance) {
+    const timerExistant = this.horaireTimers.get(seance.id);
+    if (timerExistant) {
+      clearTimeout(timerExistant);
+    }
+    this.horaireTimers.set(seance.id, setTimeout(() => {
+      this.horaireTimers.delete(seance.id);
+      this.enregistrerHoraireSeance(seance);
+    }, 500));
+  }
+
+  enregistrerHoraireAuBlur(seance: Seance) {
+    const timerExistant = this.horaireTimers.get(seance.id);
+    if (timerExistant) {
+      clearTimeout(timerExistant);
+      this.horaireTimers.delete(seance.id);
+    }
+    this.enregistrerHoraireSeance(seance);
+  }
+
+  supprimerSeance(seance: Seance) {
+    if (!this.activite.id || !seance.id) {
+      return;
+    }
+
+    const date = new Date(seance.debut).toLocaleDateString('fr-FR', {
+      weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
+    });
+    if (!confirm(`Supprimer la séance du ${date} ?`)) {
+      return;
+    }
+
+    const timerCommentaire = this.commentaireTimers.get(seance.id);
+    if (timerCommentaire) {
+      clearTimeout(timerCommentaire);
+      this.commentaireTimers.delete(seance.id);
+    }
+    const timerHoraire = this.horaireTimers.get(seance.id);
+    if (timerHoraire) {
+      clearTimeout(timerHoraire);
+      this.horaireTimers.delete(seance.id);
+    }
+    this.suppressionSeances.add(seance.id);
+    this.activiteService.supprimerSeance(this.activite.id, seance.id).subscribe({
+      next: () => {
+        this.suppressionSeances.delete(seance.id);
+        this.seances = this.seances.filter(element => element.id !== seance.id);
+        this.toastr.success('La séance a été supprimée', 'Séance supprimée');
+      },
+      error: err => {
+        this.suppressionSeances.delete(seance.id);
+        this.showError(err.message);
+      }
+    });
+  }
+
+  private aujourdHui(): string {
+    const maintenant = new Date();
+    const dateLocale = new Date(maintenant.getTime() - maintenant.getTimezoneOffset() * 60_000);
+    return dateLocale.toISOString().slice(0, 10);
+  }
+
+  private preparerSeances(seances: Seance[]): Seance[] {
+    return seances.map(seance => this.preparerSeance(seance));
+  }
+
+  private preparerSeance(seance: Seance): Seance {
+    seance.dateEdition = seance.debut?.slice(0, 10) || '';
+    seance.heureEdition = seance.debut?.slice(11, 16) || '';
+    return seance;
+  }
+
   showSucces(message: string) {
     this.toastr.success(message, 'Enregistrement réussi pour l\'activité');
   }
@@ -91,9 +304,4 @@ export class ModalActivite implements OnInit {
     this.toastr.error("Une erreur est survenue, recharger la page et recommencez. si le problème persiste contactez l'administrateur<br />" + message, 'Erreur');
   }
 
-   getEnumKeys<DayOfWeek>(): string[] {
-    return Object.keys(DayOfWeek).filter(k => isNaN(Number(k)));
-  }
-  protected readonly DayOfWeek = DayOfWeek;
 }
-

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -7,7 +7,8 @@
   },
   "files": [
     "src/main.ts",
-    "src/polyfills.ts"
+    "src/polyfills.ts",
+    "src/app/template/calendrier/calendrier.component.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,12 @@
+services:
+  app_adhesion:
+    volumes: !reset []
+    ports:
+      - "8000:8000"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://host.docker.internal:8105/${DB_NAME}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+  db_adhesion:
+    ports: !override
+      - "8106:5432"


### PR DESCRIPTION
## Résumé

Cette PR regroupe l’ensemble des évolutions demandées autour des activités, des séances et du calendrier public.

- ajout de plusieurs séances hebdomadaires à partir d’une date, en tenant compte des vacances scolaires et jours fériés ;
- affichage des séances dans la popup d’activité ;
- modification automatique de la date, de l’heure, de l’état et du commentaire ;
- suppression individuelle d’une séance ;
- conservation des séances existantes lors de la mise à jour d’une activité ;
- ajout d’un calendrier public en français, du lundi au dimanche, sur la page de connexion ;
- fusion des séances avec plusieurs Google Agendas publics à partir d’identifiants, d’URLs de partage, d’intégration ou de flux iCal ;
- prise en charge des événements récurrents, des journées entières et des erreurs partielles entre plusieurs agendas.

## Pourquoi

La gestion des séances était couplée à l’enregistrement complet de l’activité et ne disposait pas de routes REST dédiées pour toutes les opérations. Cela pouvait supprimer les séances existantes et transformer certains dispatchs d’erreur en réponses 401.

Cette PR sépare les opérations sur les séances, conserve leur collection lors de la mise à jour d’une activité et autorise explicitement les deux lectures publiques nécessaires au calendrier de connexion.

## Impact

Les administrateurs peuvent gérer chaque séance directement depuis la popup d’activité. Les visiteurs peuvent consulter les séances et les événements Google publics sans être connectés. Les flux externes sont chargés côté serveur et limités au domaine `calendar.google.com`.

Le paramètre `Google_Agendas` permet de définir les agendas affichés par défaut.

## Validation

- `npm run build` : réussi ;
- `mvn -q test` sous Java 21 : 15 tests réussis ;
- validation manuelle sur l’application locale ;
- validation avec le flux public Google des jours fériés français, incluant les événements transparents et les journées entières ;
- `git diff --check` : réussi.