### PR TITLE
Ajoute un filtre au tableau des adhérents

### DIFF
--- a/app/src/main/java/com/wild/corp/adhesion/controllers/AdherentController.java
+++ b/app/src/main/java/com/wild/corp/adhesion/controllers/AdherentController.java
@@ -126,9 +126,10 @@ public class AdherentController {
     @GetMapping("/page")
     @PreAuthorize("hasRole('SECRETAIRE') or hasRole('MODERATOR') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")
     public ResponseEntity<?> getPage(Authentication principal,
+                                     @RequestParam(defaultValue = "") String search,
                                      @PageableDefault(size = 20, sort = {"nom", "prenom"}) Pageable pageable) {
         log.info("getPage by " + principal.getName());
-        return ResponseEntity.ok(adherentServices.getPage(pageable));
+        return ResponseEntity.ok(adherentServices.getPage(search, pageable));
     }
     @GetMapping("/allExportLite")
     @PreAuthorize("hasRole('SECRETAIRE') or hasRole('MODERATOR') or hasRole('BUREAU') or hasRole('ADMINISTRATEUR') or hasRole('ADMIN')")

--- a/app/src/main/java/com/wild/corp/adhesion/repository/AdherentRepository.java
+++ b/app/src/main/java/com/wild/corp/adhesion/repository/AdherentRepository.java
@@ -2,6 +2,7 @@ package com.wild.corp.adhesion.repository;
 
 import com.wild.corp.adhesion.models.Adherent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface AdherentRepository extends JpaRepository<Adherent, Long> {
+public interface AdherentRepository extends JpaRepository<Adherent, Long>, JpaSpecificationExecutor<Adherent> {
 
     @Query(value = "SELECT adherents.* From adherents, users, users_roles WHERE adherents.user_id = users.id and users.id = users_roles.user_id and users_roles.roles_id = :roleId", nativeQuery = true)
     List<Adherent> findByUserRoleId(@Param("roleId") Long roleId);

--- a/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
+++ b/app/src/main/java/com/wild/corp/adhesion/services/AdherentServices.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -468,8 +469,22 @@ public class AdherentServices {
                 .collect(Collectors.toList());
     }
 
-    public Page<AdherentFlat> getPage(Pageable pageable) {
-        return adherentRepository.findAll(pageable).map(this::toAdherentFlat);
+    public Page<AdherentFlat> getPage(String search, Pageable pageable) {
+        Specification<Adherent> specification = (root, query, criteriaBuilder) -> {
+            if (search == null || search.isBlank()) {
+                return criteriaBuilder.conjunction();
+            }
+            String pattern = "%" + search.trim().toLowerCase() + "%";
+            return criteriaBuilder.or(
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("nom")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("prenom")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("telephone")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("adresse")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("ville")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("user").get("username")), pattern)
+            );
+        };
+        return adherentRepository.findAll(specification, pageable).map(this::toAdherentFlat);
     }
 
     private AdherentFlat toAdherentFlat(Adherent adherent) {

--- a/client/src/app/_services/adherent.service.ts
+++ b/client/src/app/_services/adherent.service.ts
@@ -73,10 +73,11 @@ export class AdherentService {
     return this.http.get<AdherentFlat[]>(API_URL + 'allFlat', { responseType: 'json' });
   }
 
-  getPage(page: number, size: number): Observable<AdherentPage> {
+  getPage(page: number, size: number, search = ''): Observable<AdherentPage> {
     const params = new HttpParams()
       .set('page', page)
       .set('size', size)
+      .set('search', search)
       .set('sort', 'nom,asc')
       .append('sort', 'prenom,asc');
     return this.http.get<AdherentPage>(API_URL + 'page', {params, responseType: 'json'});
@@ -128,4 +129,3 @@ export class AdherentService {
   }
 
 }
-

--- a/client/src/app/page/adherents/adherents.component.css
+++ b/client/src/app/page/adherents/adherents.component.css
@@ -1,6 +1,36 @@
 .ligne:hover{
     background-color: rgba(188, 219, 205, 255)!important;
   }
+.filter-panel {
+  display: flex;
+  align-items: end;
+  gap: 1rem;
+  padding: .85rem 0 .25rem;
+}
+
+.filter-field {
+  min-width: min(28rem, 100%);
+}
+
+.filter-field label {
+  display: block;
+  margin-bottom: .35rem;
+  font-size: .85rem;
+  font-weight: 700;
+  color: #526861;
+}
+
+.reset-button {
+  white-space: nowrap;
+}
+
+@media (max-width: 576px) {
+  .filter-panel {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 .table-toolbar,
 .toolbar-page-controls,
 .table-toolbar label {

--- a/client/src/app/page/adherents/adherents.component.html
+++ b/client/src/app/page/adherents/adherents.component.html
@@ -65,6 +65,18 @@
 
 <div class="row">
 
+  <div class="col-12">
+    <div class="filter-panel">
+      <div class="filter-field search-field">
+        <label for="adherent-search">Recherche</label>
+        <input id="adherent-search" type="search" class="form-control" [(ngModel)]="searchTerm"
+          (ngModelChange)="onSearchChange($event)" placeholder="Nom, prénom, e-mail, téléphone ou adresse">
+      </div>
+      <button type="button" class="btn btn-outline-secondary reset-button" (click)="resetFilters()"
+        [disabled]="!searchTerm">Réinitialiser</button>
+    </div>
+  </div>
+
   <div class="col-12 center">
     <div class="table-toolbar">
       <span *ngIf="!loadder">Résultats {{firstResult}}–{{lastResult}} sur {{totalElements}}</span>

--- a/client/src/app/page/adherents/adherents.component.ts
+++ b/client/src/app/page/adherents/adherents.component.ts
@@ -5,7 +5,7 @@ import { faPen, faUsersRays, faSkull, faUsers, faEnvelope, faCircleXmark, faClou
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TokenStorageService } from 'src/app/_services/token-storage.service';
 import { Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Subject, Subscription, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs';
 import { AuthService } from 'src/app/_services/auth.service';
 import { ParamService } from 'src/app/_services/param.service';
 import { ExcelService } from 'src/app/_services/excel.service';
@@ -38,6 +38,9 @@ export class AdherentsComponent implements OnInit {
   readonly pageSizes = [10, 20, 50, 100];
   totalElements = 0;
   totalPages = 0;
+  searchTerm = '';
+  private readonly searchChanges = new Subject<string>();
+  private readonly destroy$ = new Subject<void>();
 
   loadder:boolean=true
   errorMessage = '';
@@ -76,8 +79,19 @@ export class AdherentsComponent implements OnInit {
     } else {
       this.router.navigate(['login']);
     }
+    this.searchChanges.pipe(
+      debounceTime(350),
+      distinctUntilChanged(),
+      takeUntil(this.destroy$)
+    ).subscribe(() => this.getAdherents(true));
+
     this.getAdherents();
     this.activiteService.fillObjects(this.activites, this.activitesListe, undefined);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   getAdherents(resetPage: boolean = false) {
@@ -85,7 +99,7 @@ export class AdherentsComponent implements OnInit {
       this.page = 1;
     }
     this.loadder = true;
-    this.adherentService.getPage(this.page - 1, this.pageSize).subscribe({
+    this.adherentService.getPage(this.page - 1, this.pageSize, this.searchTerm.trim()).subscribe({
       next: (data) => {
         this.adherents = data.content;
         this.totalElements = data.totalElements;
@@ -99,6 +113,15 @@ export class AdherentsComponent implements OnInit {
         this.showError(error.error?.message || error.message);
       }
     });
+  }
+
+  onSearchChange(value: string) {
+    this.searchChanges.next(value.trim());
+  }
+
+  resetFilters() {
+    this.searchTerm = '';
+    this.getAdherents(true);
   }
 
   goToPage(targetPage: number) {


### PR DESCRIPTION
## Changements

- Ajout d’une entête de recherche au tableau des adhérents.
- Recherche sur le nom, le prénom, l’e-mail, le téléphone et l’adresse.
- Recherche côté serveur avec pagination conservée.
- Ajout d’un bouton de réinitialisation et d’une mise en page responsive.

## Impact

Le secrétariat peut maintenant retrouver un adhérent sur l’ensemble des résultats, sans être limité à la page courante.

## Validation

- Compilation backend Maven réussie avec `mvn test -q -DskipTests`.
- Vérification `git diff --check` réussie.
- Build Angular non exécuté : les dépendances `client/node_modules` ne sont pas présentes.